### PR TITLE
Removing a user attribute also removes the entire user from the session

### DIFF
--- a/code/libraries/joomlatools/library/user/session/container/abstract.php
+++ b/code/libraries/joomlatools/library/user/session/container/abstract.php
@@ -256,16 +256,24 @@ abstract class KUserSessionContainerAbstract extends KObjectArray implements KUs
      */
     public function offsetExists($identifier)
     {
-        $keys = $this->_parseIdentifier($identifier);
+        $keys   = $this->_parseIdentifier($identifier);
+        $last   = count($keys)-1;
+        $data   = &$this->_data;
+        $result = false;
 
-        foreach($keys as $key)
+        foreach($keys as $index => $key)
         {
-            if(array_key_exists($key, $this->_data)) {
-                return true;
-            };
+            if (!array_key_exists($key, $data)) {
+                break;
+            }
+
+            if ($index < $last) {
+                $data =& $data[$key];
+            }
+            else $result = true;
         }
 
-        return false;
+        return $result;
     }
 
     /**
@@ -277,14 +285,19 @@ abstract class KUserSessionContainerAbstract extends KObjectArray implements KUs
     public function offsetUnset($identifier)
     {
         $keys = $this->_parseIdentifier($identifier);
+        $last = count($keys)-1;
+        $data =& $this->_data;
 
-        foreach($keys as $key)
+        foreach($keys as $index => $key)
         {
-            if(array_key_exists($key, $this->_data))
-            {
-                unset($this->_data[$key]);
+            if (!array_key_exists($key, $data)) {
                 break;
-            };
+            }
+
+            if ($index < $last) {
+                $data =& $data[$key];
+            }
+            else unset($data[$key]);
         }
     }
 

--- a/code/libraries/joomlatools/library/user/user.php
+++ b/code/libraries/joomlatools/library/user/user.php
@@ -193,13 +193,13 @@ class KUser extends KUserAbstract implements KObjectSingleton
     /**
      * Get an user attribute
      *
-     * @param   string  $identifier Attribute identifier, eg .foo.bar
+     * @param   string  $identifier Attribute identifier, eg foo.bar
      * @param   mixed   $default    Default value when the attribute doesn't exist
      * @return  mixed   The value
      */
     public function get($identifier, $default = null)
     {
-        return $this->getSession()->get('user.attributes'.$identifier, $default);
+        return $this->getSession()->get('user.attributes.'.$identifier, $default);
     }
 
     /**
@@ -211,7 +211,7 @@ class KUser extends KUserAbstract implements KObjectSingleton
      */
     public function set($identifier, $value)
     {
-        $this->getSession()->set('user.attributes'.$identifier, $value);
+        $this->getSession()->set('user.attributes.'.$identifier, $value);
         return $this;
     }
 
@@ -223,7 +223,7 @@ class KUser extends KUserAbstract implements KObjectSingleton
      */
     public function has($identifier)
     {
-        return $this->getSession()->has('user.attributes'.$identifier);
+        return $this->getSession()->has('user.attributes.'.$identifier);
     }
 
     /**
@@ -234,7 +234,7 @@ class KUser extends KUserAbstract implements KObjectSingleton
      */
     public function remove($identifier)
     {
-        $this->getSession()->remove('user.attributes'.$identifier);
+        $this->getSession()->remove('user.attributes.'.$identifier);
         return $this;
     }
 


### PR DESCRIPTION
Following assertions all work after PR:

```

$u = KObjectManager::getInstance()->getObject('user');

assert($u->getSession()->has('user') === true);
assert($u->getSession()->has('user.email') === true);
assert($u->getSession()->has('user.attributes.admin_language') === true);
assert($u->getSession()->has('user.attributes.aslfkjaslkdfj') === false);

$u->getSession()->remove('user.attributes.admin_language');
$u->getSession()->remove('user.email');

assert($u->getSession()->has('user.attributes.admin_language') === false);
assert($u->getSession()->has('user.email') === false);
assert($u->getSession()->has('user.asldfjasldkfjd') === false);
assert($u->getSession()->has('saflkjsadf') === false);
assert($u->getSession()->has('user') === true);

$u->set('custom', 'foo');
$u->set('nested.attribute', 'foo');

assert($u->get('custom') === 'foo');
assert($u->has('custom') === true);
assert($u->get('nested.attribute') === 'foo');
assert($u->has('nested') === true);
assert($u->has('nested.attribute') === true);

$u->remove('custom');
$u->remove('nested.attribute');

assert($u->has('custom') === false);
assert($u->has('nested') === true);
assert($u->has('nested.attribute') === false);

var_dump($u->getSession()->get('user'));
```