### PR TITLE
Make the declaration of KControllerToolbarCommand::count compatible with KObjectConfig

### DIFF
--- a/code/libraries/joomlatools/library/controller/toolbar/command/command.php
+++ b/code/libraries/joomlatools/library/controller/toolbar/command/command.php
@@ -142,7 +142,7 @@ class KControllerToolbarCommand extends KObjectConfig implements KControllerTool
      *
      * @return  integer
      */
-    public function count()
+    public function count($mode = COUNT_NORMAL)
     {
         return count($this->_commands);
     }


### PR DESCRIPTION
KControllerToolbarCommand::count() should be declared as KObjectConfig::count() else it will throw a fatal error on PHP 7.
