### PR TITLE
#147 - Do not use JResponse directly. Class has been deprecated.

### DIFF
--- a/code/libraries/joomlatools/component/koowa/dispatcher/response/transport/http.php
+++ b/code/libraries/joomlatools/component/koowa/dispatcher/response/transport/http.php
@@ -64,7 +64,11 @@ class ComKoowaDispatcherResponseTransportHttp extends KDispatcherResponseTranspo
                         continue;
                     }
 
-                    JResponse::setHeader($parts[0], $parts[1]);
+                    if(version_compare(JVERSION, '3.6.5', '>=')) {
+                        JFactory::getApplication()->setHeader($parts[0], $parts[1]);
+                    } else {
+                        JResponse::setHeader($parts[0], $parts[1]);
+                    }
                 }
 
                 //Cookies

--- a/code/libraries/joomlatools/component/koowa/dispatcher/response/transport/http.php
+++ b/code/libraries/joomlatools/component/koowa/dispatcher/response/transport/http.php
@@ -64,11 +64,7 @@ class ComKoowaDispatcherResponseTransportHttp extends KDispatcherResponseTranspo
                         continue;
                     }
 
-                    if(version_compare(JVERSION, '3.6.5', '>=')) {
-                        JFactory::getApplication()->setHeader($parts[0], $parts[1]);
-                    } else {
-                        JResponse::setHeader($parts[0], $parts[1]);
-                    }
+                    JFactory::getApplication()->setHeader($parts[0], $parts[1]);
                 }
 
                 //Cookies


### PR DESCRIPTION
Replaced JResponse in Koowa with setHeader in Joomla application to prevent problems in platform when the legacy libraries are not loaded.