### PR TITLE
Fix markdown cache handling

### DIFF
--- a/code/libraries/joomlatools/library/template/engine/markdown.php
+++ b/code/libraries/joomlatools/library/template/engine/markdown.php
@@ -117,14 +117,13 @@ class KTemplateEngineMarkdown extends KTemplateEngineAbstract
         if(!$file = $this->isCached($name))
         {
             //Compile the template
-            if(!$source = $this->_compile($source)) {
+            if(!$this->_source = $this->_compile($source)) {
                 throw new RuntimeException(sprintf('The template content cannot be compiled.'));
             }
 
-            $file = $this->cache($name, $source);
+            $this->cache($name, $this->_source);
         }
-        
-        $this->_source = file_get_contents($file);
+        else  $this->_source = file_get_contents($file);
 
         return $this;
     }


### PR DESCRIPTION
@raeldc The recent change you made in the markdown cache handling didn't work as expected when cache is turned off. I have made a small fix that should resolve this. Please review