### PR TITLE
#156 Apply modal fix for solving focus issue on select2 inputs

### DIFF
--- a/code/libraries/joomlatools/library/template/helper/behavior.php
+++ b/code/libraries/joomlatools/library/template/helper/behavior.php
@@ -245,6 +245,30 @@ class KTemplateHelperBehavior extends KTemplateHelperAbstract
             static::setLoaded('modal');
         }
 
+        if(!static::isLoaded('modal-select2-fix'))
+        {
+            $html .= "<script>
+
+                // WORKAROUND FOR ISSUE: #873
+
+                kQuery(function($)
+                {
+                    $.magnificPopup.instance._onFocusIn = function(e)
+                    {
+                        // Do nothing if target element is select2 input
+                        if( $(e.target).hasClass('select2-search__field') ) {
+                            return true;
+                        }
+            
+                        // Else call parent method
+                        $.magnificPopup.proto._onFocusIn.call(this,e);
+                    };
+                });
+            </script>";
+
+            static::setLoaded('modal-select2-fix');
+        }
+
         $options   = (string)$config->options;
         $signature = md5('modal-'.$config->selector.$config->options_callback.$options);
 


### PR DESCRIPTION
**Tests instructions**

Go to backend DOCman documents view and attempt to copy/move a document. The search input should now be editable for filtering by title. This wasn't the case before.