### PR TITLE
Improvements for koowa finder plugins

### DIFF
--- a/code/libraries/joomlatools/plugin/koowa/finder.php
+++ b/code/libraries/joomlatools/plugin/koowa/finder.php
@@ -12,7 +12,7 @@ defined('JPATH_BASE') or die;
 jimport('joomla.application.component.helper');
 
 // Load the base adapter.
-require_once JPATH_ADMINISTRATOR . '/components/com_finder/helpers/indexer/adapter.php';
+JLoader::register('FinderIndexerAdapter', JPATH_ADMINISTRATOR . '/components/com_finder/helpers/indexer/adapter.php');
 
 /**
  * Finder Plugin
@@ -191,11 +191,7 @@ abstract class PlgKoowaFinder extends FinderIndexerAdapter
         FinderIndexerHelper::getContentExtras($item);
 
         // Index the item.
-        if (method_exists('FinderIndexer', 'getInstance')) {
-            FinderIndexer::getInstance()->index($item);
-        } else {
-            FinderIndexer::index($item);
-        }
+        $this->indexer->index($item);
     }
 
     /**


### PR DESCRIPTION
Hello, I already send this by mail, but here as a PR.

I've been doing some work on com_finder for 4.0 lately (and backported that to 3.x here https://www.joomlager.de/de/extensions/finder) and I encountered some issues with the DOCman plugin. Two of the three issues are fixed in this PR.

The first issue was the hardcoded require_once, which prevented me from overriding the FinderIndexerAdapter class. With the JLoader::register() call, this is made more flexible.

The second issue was the unnecessarily complicated call to JFinderIndexer::index() in the index() method. There is an internal attribute for that indexer object. :wink: 

The third issue is with the access column of com_finder. You are handing in the unchanged values from the DOCman tables, which results in negative values and unknown values for the Joomla access checks and thus in my specific case 9 out of 10 documents are not displayed, even though the user should have access to them. I have no solution for you here, how to translate this or something...

Last but not least, the indexing in general of the DOCman plugin is not really fast. It seems as if the part before the FinderIndexer::index() method call is very slow at the moment. Maybe you can find some performance gains somewhere there?