### PR TITLE
Http Caching

### DIFF
--- a/code/libraries/joomlatools/library/dispatcher/behavior/cacheable.php
+++ b/code/libraries/joomlatools/library/dispatcher/behavior/cacheable.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Joomlatools Framework - https://www.joomlatools.com/developer/framework/
+ *
+ * @copyright   Copyright (C) 2007 Johan Janssens and Timble CVBA. (http://www.timble.net)
+ * @license     GNU GPLv3 <http://www.gnu.org/licenses/gpl.html>
+ * @link        https://github.com/joomlatools/joomlatools-framework for the canonical source repository
+ */
+
+/**
+ * Cacheable Dispatcher Behavior
+ *
+ * Handle HTTP caching and validaiton. The caching logic, based on RFC 7234, uses HTTP headers to control caching
+ * behavior, cache lifetime and ETag based revalidation.
+ *
+ * @link https://tools.ietf.org/html/rfc7234
+ *
+ * @author  Johan Janssens <http://github.com/johanjanssens>
+ * @package Koowa\Library\Dispatcher\Behavior
+ */
+class KDispatcherBehaviorCacheable extends KControllerBehaviorAbstract
+{
+    /**
+     * Initializes the options for the object
+     *
+     * Called from {@link __construct()} as a first step of object instantiation.
+     *
+     * @param  KObjectConfig $config A ObjectConfig object with configuration options
+     * @return void
+     */
+    protected function _initialize(KObjectConfig  $config)
+    {
+        $config->append(array(
+            'priority' => self::PRIORITY_LOW,
+            'cache'         => true,
+            'cache_private' => false,
+            'cache_time'    => 0, //must revalidate
+        ));
+
+        parent::_initialize($config);
+    }
+
+    /**
+     * Mixin Notifier
+     *
+     * This function is called when the mixin is being mixed. It will get the mixer passed in.
+     *
+     * @param KObjectMixable $mixer The mixer object
+     * @return void
+     */
+    public function onMixin(KObjectMixable $mixer)
+    {
+        parent::onMixin($mixer);
+
+        //Set max age default
+        $this->getMixer()->getResponse()->setMaxAge($this->getConfig()->cache_time);
+    }
+
+    /**
+     * Check if the behavior is supported
+     *
+     * @return  boolean  True on success, false otherwise
+     */
+    public function isSupported()
+    {
+        return $this->isCacheable() ? parent::isSupported() : false;
+    }
+
+    /**
+     * Check if the response can be cached
+     *
+     * @return  boolean  True on success, false otherwise
+     */
+    public function isCacheable()
+    {
+        $mixer   = $this->getMixer();
+        $request = $mixer->getRequest();
+
+        $cacheable = false;
+        if($request->isCacheable() && $this->getConfig()->cache)
+        {
+            $cacheable = true;
+
+            if(!$this->getConfig()->cache_private && $mixer->getUser()->isAuthentic()) {
+                $cacheable = false;
+            }
+        }
+
+        return $cacheable;
+    }
+
+    /**
+     * Send HTTP response
+     *
+     * Prepares the Response before it is sent to the client. This method set the cache control headers to ensure that
+     * it is compliant with RFC 2616 and calculates an etag for the response
+     *
+     * @link http://tools.ietf.org/html/rfc2616
+     *
+     * @param 	KDispatcherContextInterface $context The active command context
+     * @return boolean  Returns true if the response has been send, otherwise FALSE
+     */
+    protected function _beforeSend(KDispatcherContextInterface $context)
+    {
+        $response = $context->getResponse();
+        $request  = $context->getRequest();
+
+        if($this->isCacheable())
+        {
+            $response->headers->set('Cache-Control', $this->_getCacheControl());
+
+            //Set Validator
+            $response->setEtag($this->_getEtag(), true);
+
+            //Determines if the response etag match a conditional value specified in the request.
+            if ($etags = $request->getEtags())
+            {
+                if(in_array($response->getEtag(), $etags) || in_array('*', $etags)) {
+                    $response->setStatus(KHttpResponse::NOT_MODIFIED);
+                }
+            }
+        }
+    }
+
+    /**
+     * Get the cache control directives
+     *
+     * @link https://tools.ietf.org/html/rfc7234#page-21
+     *
+     * @return array
+     */
+    protected function _getCacheControl()
+    {
+        $cache = array();
+        $response = $this->getResponse();
+
+        if($response->getUser()->isAuthentic()) {
+            $cache = array('private');
+        } else {
+            $cache = array('public');
+        }
+
+        if(0 == $cache['max-age'] = $response->getMaxAge()) {
+            $cache[] = 'no-cache';
+        };
+
+        return $cache;
+    }
+
+    /**
+     * Generate a response etag
+     *
+     * For files returns a md5 hash of same format as Apache does. Eg "%ino-%size-%0mtime" using the file
+     * info, otherwise return a crc32 digest of the response content and the user identifier
+     *
+     * @link http://stackoverflow.com/questions/44937/how-do-you-make-an-etag-that-matches-apache
+     *
+     * @return string
+     */
+    protected function _getEtag()
+    {
+        $response = $this->getResponse();
+
+        if($response->isDownloadable())
+        {
+            $info = $response->getStream()->getInfo();
+            $etag = sprintf('"%x-%x-%s"', $info['ino'], $info['size'],base_convert(str_pad($info['mtime'],16,"0"),10,16));
+        }
+        else $etag = crc32($this->getUser()->getId().'/###'.$this->getResponse()->getContent());
+
+        return $etag;
+    }
+}

--- a/code/libraries/joomlatools/library/dispatcher/request/abstract.php
+++ b/code/libraries/joomlatools/library/dispatcher/request/abstract.php
@@ -970,6 +970,29 @@ abstract class KDispatcherRequestAbstract extends KControllerRequest implements 
     }
 
     /**
+     * Gets the etags
+     *
+     * @link https://tools.ietf.org/html/rfc7232#page-14
+     *
+     * @return array The entity tags
+     */
+    public function getETags()
+    {
+        $result = array();
+        if($this->_headers->has('If-None-Match'))
+        {
+            $result = preg_split('/\s*,\s*/', $this->_headers->get('If-None-Match'), null, PREG_SPLIT_NO_EMPTY);
+
+            //Remove the encoding from the etag
+            //
+            //RFC-7232 explicitly states that ETags should be content-coding aware
+            $result = str_replace('-gzip', '', $result);
+        }
+
+        return $result;
+    }
+
+    /**
      * Checks whether the request is secure or not.
      *
      * This method can read the client scheme from the "X-Forwarded-Proto" header when the request is proxied and the

--- a/code/libraries/joomlatools/library/dispatcher/request/interface.php
+++ b/code/libraries/joomlatools/library/dispatcher/request/interface.php
@@ -216,6 +216,15 @@ interface KDispatcherRequestInterface extends KControllerRequestInterface
     public function getRanges();
 
     /**
+     * Gets the etags
+     *
+     * @link https://tools.ietf.org/html/rfc7232#page-14
+     *
+     * @return array The entity tags
+     */
+    public function getETags();
+
+    /**
      * Checks whether the request is secure or not.
      *
      * This method can read the client scheme from the "X-Forwarded-Proto" header when the request is proxied and the

--- a/code/libraries/joomlatools/library/dispatcher/response/transport/http.php
+++ b/code/libraries/joomlatools/library/dispatcher/response/transport/http.php
@@ -50,7 +50,7 @@ class KDispatcherResponseTransportHttp extends KDispatcherResponseTransportAbstr
             $headers = explode("\r\n", trim((string) $response->getHeaders()));
 
             foreach ($headers as $header) {
-                header($header, false);
+                header($header);
             }
         }
         else throw new \RuntimeException(sprintf('Headers already send (output started at %s:%s', $file, $line));
@@ -66,14 +66,12 @@ class KDispatcherResponseTransportHttp extends KDispatcherResponseTransportAbstr
      */
     public function sendContent(KDispatcherResponseInterface $response)
     {
-        //Make sure the output buffers are cleared
-        $level = ob_get_level();
-        while($level > 0) {
-            ob_end_clean();
-            $level--;
+        //Make sure we do not have body content for 204, 205 and 305 status codes
+        $codes = array(KHttpResponse::NO_CONTENT, KHttpResponse::NOT_MODIFIED, KHttpResponse::RESET_CONTENT);
+        if (!in_array($response->getStatusCode(), $codes)) {
+            echo $response->getStream()->toString();
         }
 
-        echo $response->getStream()->toString();
         return $this;
     }
 
@@ -92,12 +90,6 @@ class KDispatcherResponseTransportHttp extends KDispatcherResponseTransportAbstr
     public function send(KDispatcherResponseInterface $response)
     {
         $request = $response->getRequest();
-
-        //Make sure we do not have body content for 204, 205 and 305 status codes
-        $codes = array(KHttpResponse::NO_CONTENT, KHttpResponse::NOT_MODIFIED, KHttpResponse::RESET_CONTENT);
-        if (in_array($response->getStatusCode(), $codes)) {
-            $response->setContent(null);
-        }
 
         //Remove location header if we are not redirecting and the status code is not 201
         if(!$response->isRedirect() && $response->getStatusCode() !== KHttpResponse::CREATED)
@@ -122,6 +114,13 @@ class KDispatcherResponseTransportHttp extends KDispatcherResponseTransportAbstr
         //Add file related information if we are serving a file
         if($response->isDownloadable())
         {
+            //Make sure the output buffers are cleared
+            $level = ob_get_level();
+            while($level > 0) {
+                ob_end_clean();
+                $level--;
+            }
+
             //Last-Modified header
             if($time = $response->getStream()->getTime(KFilesystemStreamInterface::TIME_MODIFIED)) {
                 $response->setLastModified($time);
@@ -175,11 +174,6 @@ class KDispatcherResponseTransportHttp extends KDispatcherResponseTransportAbstr
             }
         }
 
-        //Add Last-Modified header if not present
-        if(!$response->headers->has('Last-Modified')) {
-            $response->setLastModified(new DateTime('now'));
-        }
-
         //Add Content-Length if not present
         if(!$response->headers->has('Content-Length')) {
             $response->headers->set('Content-Length', $response->getStream()->getSize());
@@ -190,11 +184,15 @@ class KDispatcherResponseTransportHttp extends KDispatcherResponseTransportAbstr
             $response->headers->remove('Content-Length');
         }
 
+        //set cache-control header to most conservative value.
+        $cache_control = (array) $response->headers->get('Cache-Control', null, false);
+        if (empty($cache_control) || !$request->isCacheable()) {
+            $response->headers->set('Cache-Control', array('private', 'no-cache', 'no-store'));
+        }
+
         //Modifies the response so that it conforms to the rules defined for a 304 status code.
         if($response->getStatusCode() == KHttpResponse::NOT_MODIFIED)
         {
-            $response->setContent(null);
-
             $headers = array(
                 'Allow',
                 'Content-Encoding',
@@ -208,18 +206,6 @@ class KDispatcherResponseTransportHttp extends KDispatcherResponseTransportAbstr
             //Remove headers that MUST NOT be included with 304 Not Modified responses
             foreach ($headers as $header) {
                 $response->headers->remove($header);
-            }
-        }
-
-        //Calculates or modifies the cache-control header to a sensible, conservative value.
-        $cache_control = (array) $response->headers->get('Cache-Control', null, false);
-
-        if (empty($cache_control))
-        {
-            if(!$response->isCacheable()) {
-                $response->headers->set('Cache-Control', 'no-cache');
-            } else {
-                $response->headers->set('Cache-Control', array('private', 'must-revalidate'));
             }
         }
 

--- a/code/libraries/joomlatools/library/dispatcher/response/transport/stream.php
+++ b/code/libraries/joomlatools/library/dispatcher/response/transport/stream.php
@@ -147,23 +147,6 @@ class KDispatcherResponseTransportStream extends KDispatcherResponseTransportHtt
     }
 
     /**
-     * Generate an etag from a file stream
-     *
-     * This functions returns a md5 hash of same format as Apache does. Eg "%ino-%size-%mtime" using the file info.
-     * @link http://stackoverflow.com/questions/44937/how-do-you-make-an-etag-that-matches-apache
-     *
-     * @param KDispatcherResponseInterface $response
-     * @return string
-     */
-    public function getFileEtag(KDispatcherResponseInterface $response)
-    {
-        $info = $response->getStream()->getInfo();
-        $etag = sprintf('"%x-%x-%s"', $info['ino'], $info['size'],base_convert(str_pad($info['mtime'],16,"0"),10,16));
-
-        return $etag;
-    }
-
-    /**
      * Sends content for the current web response.
      *
      * We flush(stream) the data to the output buffer based on the chunk size and range information provided in the
@@ -176,28 +159,6 @@ class KDispatcherResponseTransportStream extends KDispatcherResponseTransportHtt
     {
         if ($response->isSuccess() && $response->isStreamable())
         {
-            //For a certain unmentionable browser
-            if(ini_get('zlib.output_compression')) {
-                @ini_set('zlib.output_compression', 'Off');
-            }
-
-            //Fix for IE7/8
-            if(function_exists('apache_setenv')) {
-                @apache_setenv('no-gzip', '1');
-            }
-
-            //Remove PHP time limit
-            if(!ini_get('safe_mode')) {
-                @set_time_limit(0);
-            }
-
-            //Make sure the output buffers are cleared
-            $level = ob_get_level();
-            while($level > 0) {
-                ob_end_clean();
-                $level--;
-            }
-
             $stream  = $response->getStream();
 
             $offset = $this->getOffset($response);
@@ -233,13 +194,25 @@ class KDispatcherResponseTransportStream extends KDispatcherResponseTransportHtt
             //Explicitly set the Accept Ranges header to bytes to inform client we accept range requests
             $response->headers->set('Accept-Ranges', 'bytes');
 
-            //Set a file etag
-            $response->headers->set('etag', $this->getFileEtag($response));
-
             if($request->isStreaming())
             {
                 if($response->isSuccess())
                 {
+                    //For a certain unmentionable browser
+                    if(ini_get('zlib.output_compression')) {
+                        @ini_set('zlib.output_compression', 'Off');
+                    }
+
+                    //Fix for IE7/8
+                    if(function_exists('apache_setenv')) {
+                        @apache_setenv('no-gzip', '1');
+                    }
+
+                    //Remove PHP time limit
+                    if(!ini_get('safe_mode')) {
+                        @set_time_limit(0);
+                    }
+
                     //Default Content-Type Header
                     if(!$response->headers->has('Content-Type')) {
                         $response->headers->set('Content-Type', 'application/octet-stream');

--- a/code/libraries/joomlatools/library/http/message/headers.php
+++ b/code/libraries/joomlatools/library/http/message/headers.php
@@ -139,18 +139,6 @@ class KHttpMessageHeaders extends KObjectArray
     }
 
     /**
-     * Returns true if the given HTTP header contains the given value.
-     *
-     * @param string $key   The HTTP header name
-     * @param string $value The HTTP value
-     * @return Boolean true if the value is contained in the header, false otherwise
-     */
-    public function contains($key, $value)
-    {
-        return in_array($value, $this->get($key, null, false));
-    }
-
-    /**
      * Removes a header nu name
      *
      * @param string $key The HTTP header name
@@ -194,14 +182,24 @@ class KHttpMessageHeaders extends KObjectArray
 
             foreach ($values as $key => $value)
             {
-                if(is_numeric($key)) {
-                    $results[] = $value;
-                } else {
-                    $results[] = $key.'='.$value;
-                }
+                if(!is_numeric($key))
+                {
+                    //Parameters
+                    if(is_array($value))
+                    {
+                        $modifiers = array();
+                        foreach($value as $k => $v) {
+                            $modifiers[] = $k.'='.$v;
+                        }
 
-                $value = implode($results, '; ');
+                        $results[] = $key.';'.implode($modifiers, ',');
+                    }
+                    else $results[] = $key.'='.$value;
+                }
+                else $results[] = $value;
             }
+
+            $value = implode($results, ', ');
 
             if ($value) {
                 $content .= sprintf("%s %s\r\n", $name.':', $value);

--- a/code/libraries/joomlatools/library/http/request/interface.php
+++ b/code/libraries/joomlatools/library/http/request/interface.php
@@ -118,9 +118,9 @@ interface KHttpRequestInterface extends KHttpMessageInterface
     public function isAjax();
 
     /**
-     * Is the request a flash request
+     * Is the request cacheable
      *
      * @return boolean
      */
-    public function isFlash();
+    public function isCacheable();
 }

--- a/code/libraries/joomlatools/library/http/request/request.php
+++ b/code/libraries/joomlatools/library/http/request/request.php
@@ -242,17 +242,6 @@ class KHttpRequest extends KHttpMessage implements KHttpRequestInterface
     }
 
     /**
-     * Is this a Flash request?
-     *
-     * @return boolean
-     */
-    public function isFlash()
-    {
-        $header = $this->_headers->get('User-Agent');
-        return $header !== false && stristr($header, ' flash') || $this->_headers->has('X-Flash-Version');
-    }
-
-    /**
      * Is this a safe request?
      *
      * @link http://tools.ietf.org/html/rfc2616#section-9.1.1
@@ -261,6 +250,17 @@ class KHttpRequest extends KHttpMessage implements KHttpRequestInterface
     public function isSafe()
     {
         return $this->isGet() || $this->isHead() || $this->isOptions();
+    }
+
+    /**
+     * Is the request cacheable
+     *
+     * @link https://tools.ietf.org/html/rfc7231#section-4.2.3
+     * @return boolean
+     */
+    public function isCacheable()
+    {
+        return ($this->isGet() || $this->isHead()) && $this->_headers->get('Cache-Control') != 'no-cache';
     }
 
     /**

--- a/code/libraries/joomlatools/library/http/response/interface.php
+++ b/code/libraries/joomlatools/library/http/response/interface.php
@@ -21,7 +21,7 @@ interface KHttpResponseInterface extends KHttpMessageInterface
      * @link http://tools.ietf.org/html/rfc2616#section-6.1.1
      *
      * @param  integer $code
-     * @param  string  $message
+     * @param  string $message
      * @throws \InvalidArgumentException
      * @return KHttpResponse
      */
@@ -49,7 +49,7 @@ interface KHttpResponseInterface extends KHttpMessageInterface
      * @link http://tools.ietf.org/html/rfc2616#section-14.17
      *
      * @param string $type Content type
-     * @return HttpResponse
+     * @return KHttpResponseInterface
      */
     public function setContentType($type);
 
@@ -78,7 +78,7 @@ interface KHttpResponseInterface extends KHttpMessageInterface
      * @see http://tools.ietf.org/html/rfc2616#section-14.18
      *
      * @param  DateTime $date A \DateTime instance
-     * @return HttpResponse
+     * @return KHttpResponseInterface
      */
     public function setDate(DateTime $date);
 
@@ -104,27 +104,6 @@ interface KHttpResponseInterface extends KHttpMessageInterface
     public function setLastModified(DateTime $date = null);
 
     /**
-     * Returns the value of the Expires header as a DateTime instance.
-     *
-     * @link http://tools.ietf.org/html/rfc2616#section-14.21
-     *
-     * @return DateTime A DateTime instance
-     */
-    public function getExpires();
-
-    /**
-     * Sets the Expires HTTP header with a DateTime instance.
-     *
-     * If passed a null value, it removes the header.
-     *
-     * @link http://tools.ietf.org/html/rfc2616#section-14.21
-     *
-     * @param  DateTime $date A \DateTime instance
-     * @return HttpResponse
-     */
-    public function setExpires(DateTime $date = null);
-
-    /**
      * Returns the literal value of the ETag HTTP header.
      *
      * @link http://tools.ietf.org/html/rfc2616#section-14.19
@@ -138,9 +117,9 @@ interface KHttpResponseInterface extends KHttpMessageInterface
      *
      * @link http://tools.ietf.org/html/rfc2616#section-14.19
      *
-     * @param string  $etag The ETag unique identifier
+     * @param string $etag The ETag unique identifier
      * @param Boolean $weak Whether you want a weak ETag or not
-     * @return HttpResponse
+     * @return KHttpResponseInterface
      */
     public function setEtag($etag = null, $weak = false);
 
@@ -154,12 +133,34 @@ interface KHttpResponseInterface extends KHttpMessageInterface
     public function getAge();
 
     /**
-     * Sets the number of seconds after the time specified in the response's Date header when the the response
-     * should no longer be considered fresh.
+     * Set the age of the response.
      *
-     * Uses the expires header to calculate the maximum age. It returns null when no max age can be established.
+     * @link http://tools.ietf.org/html/rfc2616#section-14.6
+     * @param integer $age The age of the response in seconds
+     * @return KHttpResponseInterface
+     */
+    public function setAge($age);
+
+    /**
+     * Set the max age
      *
-     * @return integer|null Number of seconds
+     * This directive specifies the maximum time in seconds that the fetched response is allowed to be reused from
+     * the time of the request. For example, "max-age=60" indicates that the response can be cached and reused for
+     * the next 60 seconds.
+     *
+     * @link https://tools.ietf.org/html/rfc2616#section-14.9.3
+     * @param integer $max_age The max age of the response in seconds
+     * @return HttpResponse
+     */
+    public function setMaxAge($max_age);
+
+    /**
+     * Get the max age
+     *
+     * It returns 0 when no max age can be established.
+     *
+     * @link https://tools.ietf.org/html/rfc2616#section-14.9.3
+     * @return integer Number of seconds
      */
     public function getMaxAge();
 

--- a/code/libraries/joomlatools/library/http/response/response.php
+++ b/code/libraries/joomlatools/library/http/response/response.php
@@ -28,16 +28,23 @@ class KHttpResponse extends KHttpMessage implements KHttpResponseInterface
     /**
      * The response status message
      *
-     * @var int Status code
+     * @var string Status message
      */
     protected $_status_message;
 
     /**
      * The response content type
      *
-     * @var int Status code
+     * @var string Content type
      */
     protected $_content_type;
+
+    /**
+     * The response max age
+     *
+     * @var int Max age in seconds
+     */
+    protected $_max_age;
 
     // [Successful 2xx]
     const OK                        = 200;
@@ -47,7 +54,7 @@ class KHttpResponse extends KHttpMessage implements KHttpResponseInterface
     const RESET_CONTENT             = 205;
     const PARTIAL_CONTENT           = 206;
 
-    // [Redirection 3xx]  
+    // [Redirection 3xx]
     const MOVED_PERMANENTLY         = 301;
     const FOUND                     = 302;
     const SEE_OTHER                 = 303;
@@ -55,7 +62,7 @@ class KHttpResponse extends KHttpMessage implements KHttpResponseInterface
     const USE_PROXY                 = 305;
     const TEMPORARY_REDIRECT        = 307;
 
-    // [Client Error 4xx]  
+    // [Client Error 4xx]
     const BAD_REQUEST                   = 400;
     const UNAUTHORIZED                  = 401;
     const FORBIDDEN                     = 403;
@@ -73,7 +80,7 @@ class KHttpResponse extends KHttpMessage implements KHttpResponseInterface
     const REQUESTED_RANGE_NOT_SATISFIED = 416;
     const EXPECTATION_FAILED            = 417;
 
-    // [Server Error 5xx]  
+    // [Server Error 5xx]
     const INTERNAL_SERVER_ERROR     = 500;
     const NOT_IMPLEMENTED           = 501;
     const BAD_GATEWAY               = 502;
@@ -102,7 +109,7 @@ class KHttpResponse extends KHttpMessage implements KHttpResponseInterface
         205 => 'Reset Content',
         206 => 'Partial Content',
 
-        // [Redirection 3xx]  
+        // [Redirection 3xx]
         300 => 'Multiple Choices',
         301 => 'Moved Permanently',
         302 => 'Found',
@@ -111,7 +118,7 @@ class KHttpResponse extends KHttpMessage implements KHttpResponseInterface
         305 => 'Use Proxy',
         307 => 'Temporary Redirect',
 
-        // [Client Error 4xx]  
+        // [Client Error 4xx]
         400 => 'Bad Request',
         401 => 'Unauthorized',
         403 => 'Forbidden',
@@ -129,7 +136,7 @@ class KHttpResponse extends KHttpMessage implements KHttpResponseInterface
         416 => 'Requested Range Not Satisfiable',
         417 => 'Expectation Failed',
 
-        // [Server Error 5xx]  
+        // [Server Error 5xx]
         500 => 'Internal Server Error',
         501 => 'Not Implemented',
         502 => 'Bad Gateway',
@@ -253,7 +260,7 @@ class KHttpResponse extends KHttpMessage implements KHttpResponseInterface
     public function setContentType($type)
     {
         $this->_content_type = $type;
-        $this->_headers->set('Content-Type', array($type, 'charset' => 'utf-8'));
+        $this->_headers->set('Content-Type', array($type => array('charset' => 'utf-8')));
 
         return $this;
     }
@@ -288,7 +295,7 @@ class KHttpResponse extends KHttpMessage implements KHttpResponseInterface
             $date  = new DateTime(date(DATE_RFC2822, strtotime($value)));
 
             if ($date === false) {
-                throw new RuntimeException(sprintf('The Last-Modified HTTP header is not parseable (%s).', $value));
+                throw new RuntimeException(sprintf('The Date HTTP header is not parseable (%s).', $value));
             }
         }
 
@@ -360,54 +367,6 @@ class KHttpResponse extends KHttpMessage implements KHttpResponseInterface
     }
 
     /**
-     * Returns the value of the Expires header as a DateTime instance.
-     *
-     * @link http://tools.ietf.org/html/rfc2616#section-14.21
-     *
-     * @throws RuntimeException If the Expires header could not be parsed
-     * @return DateTime|null A DateTime instance or NULL if no Expires header exists
-     */
-    public function getExpires()
-    {
-        $date = null;
-
-        if ($this->_headers->has('Expires'))
-        {
-            $value = $this->_headers->get('Expires');
-            $date  = new DateTime(date(DATE_RFC2822, strtotime($value)));
-
-            if ($date === false) {
-                throw new RuntimeException(sprintf('The Expires HTTP header is not parseable (%s).', $value));
-            }
-        }
-
-        return $date;
-    }
-
-    /**
-     * Sets the Expires HTTP header with a DateTime instance.
-     *
-     * If passed a null value, it removes the header.
-     *
-     * @link http://tools.ietf.org/html/rfc2616#section-14.21
-     *
-     * @param  DateTime $date A \DateTime instance
-     * @return HttpResponse
-     */
-    public function setExpires(DateTime $date = null)
-    {
-        if (null !== $date)
-        {
-            $date = clone $date;
-            $date->setTimezone(new DateTimeZone('UTC'));
-            $this->_headers->set('Expires', $date->format('D, d M Y H:i:s').' GMT');
-
-        } else $this->_headers->remove('Expires');
-
-        return $this;
-    }
-
-    /**
      * Returns the literal value of the ETag HTTP header.
      *
      * @link http://tools.ietf.org/html/rfc2616#section-14.19
@@ -444,6 +403,19 @@ class KHttpResponse extends KHttpMessage implements KHttpResponseInterface
     }
 
     /**
+     * Set the age of the response.
+     *
+     * @link http://tools.ietf.org/html/rfc2616#section-14.6
+     * @param integer $age The age of the response in seconds
+     * @return HttpResponse
+     */
+    public function setAge($age)
+    {
+        $this->_headers->set('Age', $age);
+        return $this;
+    }
+
+    /**
      * Returns the age of the response.
      *
      * @link http://tools.ietf.org/html/rfc2616#section-14.6
@@ -451,28 +423,48 @@ class KHttpResponse extends KHttpMessage implements KHttpResponseInterface
      */
     public function getAge()
     {
-        if ($age = $this->_headers->get('Age')) {
-            return $age;
+        if (!$age = $this->_headers->get('Age', 0)) {
+            $age = max(time() - $this->getDate()->format('U'), 0);
         }
 
-        return max(time() - $this->getDate()->format('U'), 0);
+        return $age;
     }
 
     /**
-     * Sets the number of seconds after the time specified in the response's Date header when the the response
-     * should no longer be considered fresh.
+     * Set the max age
      *
-     * Uses the expires header to calculate the maximum age. It returns null when no max age can be established.
+     * This directive specifies the maximum time in seconds that the fetched response is allowed to be reused from
+     * the time of the request. For example, "max-age=60" indicates that the response can be cached and reused for
+     * the next 60 seconds.
      *
-     * @return integer|null Number of seconds
+     * @link https://tools.ietf.org/html/rfc2616#section-14.9.3
+     * @param integer $max_age The max age of the response in seconds
+     * @return HttpResponse
+     */
+    public function setMaxAge($max_age)
+    {
+        $this->_max_age = $max_age;
+        return $this;
+    }
+
+    /**
+     * Get the max age
+     *
+     * It returns 0 when no max age can be established.
+     *
+     * @link https://tools.ietf.org/html/rfc2616#section-14.9.3
+     * @return integer Number of seconds
      */
     public function getMaxAge()
     {
-        if ($this->getExpires() !== null) {
-            return $this->getExpires()->format('U') - $this->getDate()->format('U');
+        $cache_control = (array) $this->_headers->get('Cache-Control', null, false);
+        if (isset($cache_control['max-age'])) {
+            $result = $cache_control['max-age'];
+        } else {
+            $result = (int) $this->_max_age;
         }
 
-        return null;
+        return (int) $result;
     }
 
     /**
@@ -484,7 +476,6 @@ class KHttpResponse extends KHttpMessage implements KHttpResponseInterface
     {
         return $this->_status_code < 100 || $this->_status_code >= 600;
     }
-
 
     /**
      * Check if an http status code is an error
@@ -503,8 +494,7 @@ class KHttpResponse extends KHttpMessage implements KHttpResponseInterface
      */
     public function isRedirect()
     {
-        $code = $this->getStatusCode();
-        return (300 <= $code && 400 > $code);
+        return in_array($this->getStatusCode(), array(301, 302, 303, 307, 308));
     }
 
     /**
@@ -519,6 +509,29 @@ class KHttpResponse extends KHttpMessage implements KHttpResponseInterface
     }
 
     /**
+     * Returns true if the response is worth caching under any circumstance.
+     *
+     * Responses that cannot be stored or are without cache validation (Last-Modified, ETag) heades are
+     * considered uncacheable.
+     *
+     * @link http://tools.ietf.org/html/rfc2616#section-14.9.1
+     * @return Boolean true if the response is worth caching, false otherwise
+     */
+    public function isCacheable()
+    {
+        if (!in_array($this->_status_code, array(200, 203, 300, 301, 302, 304, 404, 410))) {
+            return false;
+        }
+
+        $cache_control = (array) $this->_headers->get('Cache-Control', null, false);
+        if (isset($cache_control['no-store'])) {
+            return false;
+        }
+
+        return $this->isValidateable();
+    }
+
+    /**
      * Returns true if the response includes headers that can be used to validate the response with the origin
      * server using a conditional GET request.
      *
@@ -527,29 +540,6 @@ class KHttpResponse extends KHttpMessage implements KHttpResponseInterface
     public function isValidateable()
     {
         return $this->_headers->has('Last-Modified') || $this->_headers->has('ETag');
-    }
-
-    /**
-     * Returns true if the response is worth caching under any circumstance.
-     *
-     * Responses with that are stale (Expired) or without cache validation (Last-Modified, ETag) heades are
-     * considered uncacheable.
-     *
-     * @link http://tools.ietf.org/html/rfc2616#section-14.9.1
-     * @return Boolean true if the response is worth caching, false otherwise
-     */
-    public function isCacheable()
-    {
-        if (!in_array($this->_status_code, array(200, 203, 300, 301, 302, 404, 410))) {
-            return false;
-        }
-
-        $cache_control = (array) $this->_headers->get('Cache-Control', null, false);
-        if (isset($cache_control['no-store']) || isset($cache_control['no-cache'])) {
-            return false;
-        }
-
-        return $this->isValidateable() || !$this->isStale();
     }
 
     /**


### PR DESCRIPTION
Implement http caching support through cacheable dispatcher behavior with etag based validation.

This PR requires: https://github.com/joomlatools/joomlatools-framework/pull/180 and and it's best to read up on https://github.com/joomlatools/joomlatools-framework/issues/36 to if you are not familiar with http caching

## Browser Caching

#### Cache Key

A weak etag is used:

- Resource: content + user id 
- File: Using the file info to create an Apache style etag

Note: By suing a weak etag we offer support for CloudFlare as they require weak etags, strong etags are only supported for enterprise customers and automatically disabled specific features. ([more info](https://support.cloudflare.com/hc/en-us/articles/218505467-Does-Cloudflare-support-ETag-headers-))

#### Invalidation

Cache validation is done based on the etag, and max-age information. For details on the mechanism please see: https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching

## Server caching

This framework doesn't implement a mechanism for server side caching, the behavior could be specialised to implement server side caching or, a http proxy cache could be used:

- https://symfony.com/doc/2.1/book/http_cache.html
- https://guzzle3.readthedocs.io/plugins/cache-plugin.html
- http://docs.php-http.org/en/latest/plugins/cache.html

## Notable changes

- We no longer clean all php buffers when sending the request, this is only done when send a file. This approach allows for easier integration of the framework into another application. The application should define how it wishes to buffer the output generated.

- We no longer clean the response stream buffer for 304 responses. Instead the response stream buffer is not send to the php output buffer. This change allows to get access to the buffer contents after it has been send to the output buffer, for caching purposes for example.

## Removed methods

- KHttpRequest::isFlash()
- KHttpResponse::getExpires() (*)
- KHttpResponse::setExpires(). (*) 

Expires headers are considered deprecated headers, etag or last-modified date validation should be used instead.
