### PR TITLE
Allow decoration of JSON views

### DIFF
--- a/code/libraries/joomlatools/library/dispatcher/response/abstract.php
+++ b/code/libraries/joomlatools/library/dispatcher/response/abstract.php
@@ -117,7 +117,7 @@ abstract class KDispatcherResponseAbstract extends KControllerResponse implement
         if($this->__stream instanceof KFilesystemStreamInterface)
         {
             $this->__stream->truncate(0);
-            $this->__stream->write($content);
+            $this->__stream->write((string) $content);
         }
 
         return parent::setContent($content, $type);

--- a/code/libraries/joomlatools/library/http/message/message.php
+++ b/code/libraries/joomlatools/library/http/message/message.php
@@ -152,7 +152,7 @@ abstract class KHttpMessage extends KObject implements KHttpMessageInterface
         }
 
         //Cast to a string
-        $this->_content = (string) $content;
+        $this->_content = $content;
 
         if(isset($type)) {
             $this->setContentType($type);

--- a/code/libraries/joomlatools/library/object/config/json.php
+++ b/code/libraries/joomlatools/library/object/config/json.php
@@ -48,7 +48,14 @@ class KObjectConfigJson extends KObjectConfigFormat
     public function toString()
     {
         $data = $this->toArray();
-        $data = json_encode($data);
+
+        // Root should be JSON object, not array
+        if (count($data) === 0) {
+            $data = new ArrayObject();
+        }
+
+        // Encode <, >, ', &, and " for RFC4627-compliant JSON, which may also be embedded into HTML.
+        $data = json_encode($data, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT);
 
         if($data === false) {
             throw new DomainException('Cannot encode data to JSON string');

--- a/code/libraries/joomlatools/library/view/abstract.php
+++ b/code/libraries/joomlatools/library/view/abstract.php
@@ -147,13 +147,13 @@ abstract class KViewAbstract extends KObject implements KViewInterface, KCommand
      */
     protected function _actionRender(KViewContext $context)
     {
-        $contents = $this->getContent();
+        $content = $this->getContent();
 
-        if(is_string($contents)) {
-            $contents = trim($contents);
+        if(is_string($content)) {
+            $content = trim($content);
         }
 
-        return $contents;
+        return $content;
     }
 
     /**
@@ -293,11 +293,19 @@ abstract class KViewAbstract extends KObject implements KViewInterface, KCommand
     /**
      * Get the contents
      *
-     * @param  string $content The contents of the view
+     * @param  object|string $content The contents of the view
+     * @throws \UnexpectedValueException If the content is not a string are cannot be casted to a string.
      * @return KViewAbstract
      */
     public function setContent($content)
     {
+        if (!is_null($content) && !is_string($content) && !is_numeric($content) && !is_callable(array($content, '__toString')))
+        {
+            throw new UnexpectedValueException(
+                'The view content content must be a string or object implementing __toString(), "'.gettype($content).'" given.'
+            );
+        }
+
         $this->_content = $content;
         return $this;
     }

--- a/code/libraries/joomlatools/library/view/abstract.php
+++ b/code/libraries/joomlatools/library/view/abstract.php
@@ -148,7 +148,12 @@ abstract class KViewAbstract extends KObject implements KViewInterface, KCommand
     protected function _actionRender(KViewContext $context)
     {
         $contents = $this->getContent();
-        return trim($contents);
+
+        if(is_string($contents)) {
+            $contents = trim($contents);
+        }
+
+        return $contents;
     }
 
     /**

--- a/code/libraries/joomlatools/library/view/interface.php
+++ b/code/libraries/joomlatools/library/view/interface.php
@@ -88,14 +88,15 @@ interface KViewInterface
     /**
      * Get the content
      *
-     * @return  string The content of the view
+     * @return  object|string The content of the view
      */
     public function getContent();
 
     /**
      * Get the content
      *
-     * @param  string $content The content of the view
+     * @param  object|string $content The content of the view
+     * @throws \UnexpectedValueException If the content is not a string are cannot be casted to a string.
      * @return KViewInterface
      */
     public function setContent($content);

--- a/code/libraries/joomlatools/library/view/json.php
+++ b/code/libraries/joomlatools/library/view/json.php
@@ -101,17 +101,9 @@ class KViewJson extends KViewAbstract
         }
 
         //Serialise
-        if (!is_string($this->_content))
-        {
-            // Root should be JSON object, not array
-            if (is_array($this->_content) && count($this->_content) === 0) {
-                $this->_content = new ArrayObject();
-            }
-
-            // Encode <, >, ', &, and " for RFC4627-compliant JSON, which may also be embedded into HTML.
-            $this->_content = json_encode($this->_content, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT);
+        if (is_array($this->_content)) {
+            $this->_content = new KObjectConfigJson($this->_content);
         }
-
 
         return parent::_actionRender($context);
     }

--- a/code/libraries/joomlatools/library/view/json.php
+++ b/code/libraries/joomlatools/library/view/json.php
@@ -94,16 +94,19 @@ class KViewJson extends KViewAbstract
      */
     protected function _actionRender(KViewContext $context)
     {
-        if (empty($this->_content))
+        $content = $this->getContent();
+
+        if (empty($content))
         {
-            $this->_content = $this->_renderData();
-            $this->_processLinks($this->_content);
+            $content = $this->_renderData();
+            $this->_processLinks($content);
         }
 
-        //Serialise
-        if (is_array($this->_content)) {
-            $this->_content = new KObjectConfigJson($this->_content);
+        if (is_array($content) || $content instanceof \Traversable) {
+            $content = new KObjectConfigJson($content);
         }
+
+        $this->setContent($content);
 
         return parent::_actionRender($context);
     }

--- a/code/libraries/joomlatools/library/view/template.php
+++ b/code/libraries/joomlatools/library/view/template.php
@@ -108,10 +108,13 @@ abstract class KViewTemplate extends KViewAbstract
         $data = KObjectConfig::unbox($context->data);
 
         //Render the template
-        $this->_content = $this->getTemplate()
+        $content = $this->getTemplate()
             ->loadFile((string) $layout.'.'.$format)
             ->setParameters($context->parameters)
             ->render($data);
+
+        //Set the content
+        $this->setContent($content);
 
         return parent::_actionRender($context);
     }


### PR DESCRIPTION
Implement support for JSON view decoration by returning the JSON from the view as KObjectConfigJson object, only casting to string when the content is set in the response stream buffer. 

Note: This PR changes the default implementation of KObjectConfigJson, extra testing should be done to ensure the changes are BC. 