### PR TITLE
Consistently return base URL

### DIFF
--- a/code/libraries/joomlatools/library/http/url/url.php
+++ b/code/libraries/joomlatools/library/http/url/url.php
@@ -384,7 +384,7 @@ class KHttpUrl extends KObject implements KHttpUrlInterface
         if (is_string($path))
         {
             if (!empty($path)) {
-                $path = explode('/', rtrim($path, '/\\'));
+                $path = explode('/', rtrim($path, '/\\');
             } else {
                 $path = array();
             }

--- a/code/libraries/joomlatools/library/http/url/url.php
+++ b/code/libraries/joomlatools/library/http/url/url.php
@@ -384,7 +384,7 @@ class KHttpUrl extends KObject implements KHttpUrlInterface
         if (is_string($path))
         {
             if (!empty($path)) {
-                $path = explode('/', rtrim($path, '/\\');
+                $path = explode('/', $path);
             } else {
                 $path = array();
             }

--- a/code/libraries/joomlatools/library/http/url/url.php
+++ b/code/libraries/joomlatools/library/http/url/url.php
@@ -384,7 +384,7 @@ class KHttpUrl extends KObject implements KHttpUrlInterface
         if (is_string($path))
         {
             if (!empty($path)) {
-                $path = explode('/', $path);
+                $path = explode('/', rtrim($path, '/\\');
             } else {
                 $path = array();
             }

--- a/code/libraries/joomlatools/library/http/url/url.php
+++ b/code/libraries/joomlatools/library/http/url/url.php
@@ -384,7 +384,7 @@ class KHttpUrl extends KObject implements KHttpUrlInterface
         if (is_string($path))
         {
             if (!empty($path)) {
-                $path = explode('/', rtrim($path, '/\\');
+                $path = explode('/', rtrim($path, '/\\'));
             } else {
                 $path = array();
             }

--- a/code/plugins/system/joomlatools/joomlatools.php
+++ b/code/plugins/system/joomlatools/joomlatools.php
@@ -178,7 +178,7 @@ class PlgSystemJoomlatools extends JPlugin
             if (JFactory::getApplication()->getCfg('live_site'))
             {
                 $request->setBasePath(rtrim(JURI::base(true), '/\\'));
-                $request->setBaseUrl($manager->getObject('lib:http.url', array('url' => JURI::base())));
+                $request->setBaseUrl($manager->getObject('lib:http.url', array('url' => rtrim(JURI::base(), '/\\'))));
             }
 
             //Exception Handling


### PR DESCRIPTION
fixes #214 

### The problem

The trailing slash on base URL is present when the live_site variable is set within the configuration.php file. Under these conditions the FW sets the base url as follows (joomlatools sytem plugin):

`$request->setBaseUrl($manager->getObject('lib:http.url',` array('url' => JURI::base())));
`
`JURI::base() `always contains a trailing /, therefore $request->getBaseUrl()->toString() will also have it.

### Possible approaches

We have two approaches:

1. We always remove trailing slashes when setting the path. This ensures that a path will never have a trailing /. It solves the problem and then more. We have code all over the place double checking this. This approach would allow us to remove those checks and therefore cleanup the code.
2. We may remove the trailing slash from the `JURI::base()` call:

`$request->setBaseUrl($manager->getObject('lib:http.url',` array('url' => rtrim(JURI::base(), '/\\'))));
`
This would solve the trailing / problem when grabbing the base/site URL only. 

@ercanozkaya @johanjanssens Please let me know what you think guys.