### PR TITLE
Trim slashes

### DIFF
--- a/code/libraries/joomlatools/library/http/url/url.php
+++ b/code/libraries/joomlatools/library/http/url/url.php
@@ -383,6 +383,8 @@ class KHttpUrl extends KObject implements KHttpUrlInterface
     {
         if (is_string($path))
         {
+            $path = trim($path, '/');
+
             if (!empty($path)) {
                 $path = explode('/', $path);
             } else {
@@ -577,7 +579,7 @@ class KHttpUrl extends KObject implements KHttpUrlInterface
         // elements to allow for string-zero values.
         if (($parts & self::PATH) && !empty($this->_path))
         {
-            $url .= $this->getPath();
+            $url .= '/'.$this->getPath();
         }
 
         if (($parts & self::QUERY) && !empty($this->_query))

--- a/code/libraries/joomlatools/library/http/url/url.php
+++ b/code/libraries/joomlatools/library/http/url/url.php
@@ -383,7 +383,7 @@ class KHttpUrl extends KObject implements KHttpUrlInterface
     {
         if (is_string($path))
         {
-            $path = trim($path, '/');
+            $path = ltrim($path, '/');
 
             if (!empty($path)) {
                 $path = explode('/', $path);


### PR DESCRIPTION
This could be related too #214 unsure. It will need some decent testing as it can generate unexpected results, problems might happen where getPath() is used to retrieve the path, paths are no longer returned with a leading slash.