### PR TITLE
An empty entity should be  composite

### DIFF
--- a/code/libraries/joomlatools/library/model/abstract.php
+++ b/code/libraries/joomlatools/library/model/abstract.php
@@ -255,7 +255,7 @@ abstract class KModelAbstract extends KObject implements KModelInterface, KComma
         $identifier = $this->getIdentifier()->toArray();
         $identifier['path'] = array('model', 'entity');
 
-        if(!is_numeric(key($data))) {
+        if($data && !is_numeric(key($data))) {
             $identifier['name'] = KStringInflector::singularize($identifier['name']);
         } else {
             $identifier['name'] = KStringInflector::pluralize($identifier['name']);


### PR DESCRIPTION
In the framework we are working towards the concept that an entity is always a composite. This isn't the case yet, but we should at least ensure that if you create an epmty one you are being returned a composite.

Impact of this change should be minimal, database layer overrides this method, only components that use the abstract model directly could be affected.