### PR TITLE
Platform compatibility for template overrides

### DIFF
--- a/code/libraries/joomlatools/component/koowa/template/locator/component.php
+++ b/code/libraries/joomlatools/component/koowa/template/locator/component.php
@@ -44,15 +44,19 @@ class ComKoowaTemplateLocatorComponent extends KTemplateLocatorComponent
      */
     protected function _initialize(KObjectConfig $config)
     {
-        $query = $this->getObject('lib:database.query.select')
-            ->table('template_styles')
-            ->columns('template')
-            ->where('client_id = :client_id AND home = :home')
-            ->bind(array(
-                'client_id' => JFactory::getApplication()->getClientId(), 'home' => 1
-            ));
+        if(!defined('JOOMLATOOLS_PLATFORM'))
+        {
+            $query = $this->getObject('lib:database.query.select')
+                ->table('template_styles')
+                ->columns('template')
+                ->where('client_id = :client_id AND home = :home')
+                ->bind(array(
+                    'client_id' => JFactory::getApplication()->getClientId(), 'home' => 1
+                ));
 
-        $template = $this->getObject('lib:database.adapter.mysqli')->select($query, KDatabase::FETCH_FIELD);
+            $template = $this->getObject('lib:database.adapter.mysqli')->select($query, KDatabase::FETCH_FIELD);
+        }
+        else $template = JFactory::getApplication()->getTemplate();
 
         $config->append([
             'override_paths' => [

--- a/code/libraries/joomlatools/component/koowa/template/locator/file.php
+++ b/code/libraries/joomlatools/component/koowa/template/locator/file.php
@@ -44,13 +44,17 @@ class ComKoowaTemplateLocatorFile extends KTemplateLocatorFile
      */
     protected function _initialize(KObjectConfig $config)
     {
-        $query = $this->getObject('lib:database.query.select')
-                      ->table('template_styles')
-                      ->columns('template')
-                      ->where('client_id = :client_id AND home = :home')
-                      ->bind(array('client_id' => 0, 'home' => 1));
+        if(!defined('JOOMLATOOLS_PLATFORM'))
+        {
+            $query = $this->getObject('lib:database.query.select')
+                ->table('template_styles')
+                ->columns('template')
+                ->where('client_id = :client_id AND home = :home')
+                ->bind(array('client_id' => 0, 'home' => 1));
 
-        $template = $this->getObject('lib:database.adapter.mysqli')->select($query, KDatabase::FETCH_FIELD);
+            $template = $this->getObject('lib:database.adapter.mysqli')->select($query, KDatabase::FETCH_FIELD);
+        }
+        else  $template = JFactory::getApplication()->getTemplate();
 
         $config->append(array(
             'override_paths' => [

--- a/code/libraries/joomlatools/component/koowa/template/locator/module.php
+++ b/code/libraries/joomlatools/component/koowa/template/locator/module.php
@@ -51,15 +51,19 @@ class ComKoowaTemplateLocatorModule extends KTemplateLocatorIdentifier
      */
     protected function _initialize(KObjectConfig $config)
     {
-        $query = $this->getObject('lib:database.query.select')
-            ->table('template_styles')
-            ->columns('template')
-            ->where('client_id = :client_id AND home = :home')
-            ->bind(array(
-                'client_id' => JFactory::getApplication()->getClientId(), 'home' => 1
-            ));
+        if(!defined('JOOMLATOOLS_PLATFORM'))
+        {
+            $query = $this->getObject('lib:database.query.select')
+                ->table('template_styles')
+                ->columns('template')
+                ->where('client_id = :client_id AND home = :home')
+                ->bind(array(
+                    'client_id' => JFactory::getApplication()->getClientId(), 'home' => 1
+                ));
 
-        $template = $this->getObject('lib:database.adapter.mysqli')->select($query, KDatabase::FETCH_FIELD);
+            $template = $this->getObject('lib:database.adapter.mysqli')->select($query, KDatabase::FETCH_FIELD);
+        }
+        else $template = JFactory::getApplication()->getTemplate();
 
         $config->append([
             'override_paths' => [


### PR DESCRIPTION
The templates_styles table doesn't exist on platform, query can not be executed, resolving the problem by adding an additional platform check.

@ercanozkaya Why are we not querying the templates table? Why query the templates_styles table? Querying templates table would make the code compatible with platform