### PR TITLE
#243: Always encode the file name for Internet Explorer

### DIFF
--- a/code/libraries/joomlatools/library/dispatcher/response/transport/http.php
+++ b/code/libraries/joomlatools/library/dispatcher/response/transport/http.php
@@ -147,13 +147,13 @@ class KDispatcherResponseTransportHttp extends KDispatcherResponseTransportAbstr
 
                 $directives = array('filename' => '"'.$filename.'"');
 
-                // IE7 and 8 accepts percent encoded file names as the filename value
+                // IE accepts percent encoded file names as the filename value
                 // Other browsers (except Safari) use filename* header starting with UTF-8''
                 $encoded_name = rawurlencode($filename);
 
                 if($encoded_name !== $filename)
                 {
-                    if (preg_match('/(?i)MSIE [4-8]/i', $user_agent)) {
+                    if (preg_match('/(?:\b(MS)?IE\s+|\bTrident\/7\.0;.*\s+rv:)(\d+)/i', $user_agent)) {
                         $directives['filename'] = '"'.$encoded_name.'"';
                     }
                     elseif (!stripos($user_agent, 'AppleWebkit')) {


### PR DESCRIPTION
Closes #243 