### PR TITLE
Improve http format handling

### DIFF
--- a/code/libraries/joomlatools/library/dispatcher/request/abstract.php
+++ b/code/libraries/joomlatools/library/dispatcher/request/abstract.php
@@ -116,11 +116,6 @@ abstract class KDispatcherRequestAbstract extends KControllerRequest implements 
         //Set the base path
         $this->setBasePath($config->base_path);
 
-        //Set the formats
-        foreach(KObjectConfig::unbox($config->formats) as $format => $mediatype) {
-            $this->addFormat($format, $mediatype);
-        }
-
         //Set document root for IIS
         if(!isset($_SERVER['DOCUMENT_ROOT']))
         {
@@ -233,23 +228,8 @@ abstract class KDispatcherRequestAbstract extends KControllerRequest implements 
         $config->append(array(
             'base_url'  => '/',
             'base_path' => null,
-            'format'    => null,
             'url'       => null,
             'method'   => null,
-            'formats'  => array(
-                'html'       => array('text/html', 'application/xhtml+xml'),
-                'txt'        => array('text/plain'),
-                'csv'        => array('text/csv'),
-                'js'         => array('application/javascript', 'application/x-javascript', 'text/javascript'),
-                'css'        => array('text/css'),
-                'json'       => array('application/json', 'application/x-json', 'application/vnd.api+json'),
-                'xml'        => array('text/xml', 'application/xml', 'application/x-xml'),
-                'rdf'        => array('application/rdf+xml'),
-                'atom'       => array('application/atom+xml'),
-                'rss'        => array('application/xml', 'application/rss+xml'),
-                'jsonstream' => array('application/stream+json'),
-                'binary'     => array('application/octet-stream'),
-            ),
             'query'   => $_GET,
             'data'    => $_POST,
             'cookies' => $_COOKIE,
@@ -390,31 +370,6 @@ abstract class KDispatcherRequestAbstract extends KControllerRequest implements 
         }
 
         return $this->_content;
-    }
-
-    /**
-     * Get the POST or PUT content type
-     *
-     * @return  string   The content type
-     */
-    public function getContentType()
-    {
-        if (empty($this->_content_type) && $this->_headers->has('Content-Type'))
-        {
-            $type = $this->_headers->get('Content-Type');
-
-            //Strip parameters from content-type like "; charset=UTF-8"
-            if (is_string($type))
-            {
-                if (preg_match('/^([^,\;]*)/', $type, $matches)) {
-                    $type = $matches[1];
-                }
-            }
-
-            $this->_content_type = $type;
-        }
-
-        return $this->_content_type;
     }
 
     /**
@@ -566,7 +521,7 @@ abstract class KDispatcherRequestAbstract extends KControllerRequest implements 
      * Set the url for this request
      *
      * @param string|array  $url Part(s) of an URL in form of a string or associative array like parse_url() returns
-     * @return HttpRequest
+     * @return KHttpRequest
      */
     public function setUrl($url)
     {
@@ -732,7 +687,7 @@ abstract class KDispatcherRequestAbstract extends KControllerRequest implements 
      * Set the base URL for which the request is executed.
      *
      * @param string $url
-     * @return KDispatcherRequest
+     * @return KDispatcherRequestAbstract
      */
     public function setBaseUrl($url)
     {
@@ -770,7 +725,7 @@ abstract class KDispatcherRequestAbstract extends KControllerRequest implements 
      * Set the base path for which the request is executed.
      *
      * @param string $path
-     * @return KDispatcherRequest
+     * @return KDispatcherRequestAbstract
      */
     public function setBasePath($path)
     {
@@ -834,41 +789,6 @@ abstract class KDispatcherRequestAbstract extends KControllerRequest implements 
         }
 
         return $mediatype ? static::$_formats[$this->_format][0] : $this->_format;
-    }
-
-    /**
-     * Sets a format
-     *
-     * @param string $format The format
-     * @throws UnexpectedValueException If the format hasn't been registered.
-     * @return $this
-     */
-    public function setFormat($format)
-    {
-        if($format)
-        {
-            if(!isset(static::$_formats[$format])) {
-                throw new UnexpectedValueException('Unregistered format: "' . $format . '" given.');
-            }
-
-            $this->_format = $format;
-        }
-
-        return $this;
-    }
-
-    /**
-     * Associates a format with mime types.
-     *
-     * @param string       $format     The format
-     * @param string|array $mime_types The associated mime types (the preferred one must be the first as it will be used
-     *                                as the content type)
-     * @return KDispatcherRequest
-     */
-    public function addFormat($format, $mime_types)
-    {
-        static::$_formats[$format] = is_array($mime_types) ? $mime_types : array($mime_types);
-        return $this;
     }
 
     /**

--- a/code/libraries/joomlatools/library/dispatcher/request/interface.php
+++ b/code/libraries/joomlatools/library/dispatcher/request/interface.php
@@ -170,28 +170,6 @@ interface KDispatcherRequestInterface extends KControllerRequestInterface
     public function setBasePath($path);
 
     /**
-     * Return the request format
-     *
-     * Find the format by using following sequence :
-     *
-     * 1. Use the the 'format' request parameter
-     * 2. Use the accept header with the highest quality apply the reverse format map to find the format.
-     *
-     * @return  string  The request format or NULL if no format could be found
-     */
-    public function getFormat();
-
-    /**
-     * Associates a format with mime types.
-     *
-     * @param string       $format     The format
-     * @param string|array $mime_types The associated mime types (the preferred one must be the first as it will be used
-     *                                as the content type)
-     * @return KDispatcherRequestInterface
-     */
-    public function addFormat($format, $mime_types);
-
-    /**
      * Gets a list of languages acceptable by the client browser.
      *
      * @return array Languages ordered in the user browser preferences

--- a/code/libraries/joomlatools/library/dispatcher/response/abstract.php
+++ b/code/libraries/joomlatools/library/dispatcher/response/abstract.php
@@ -145,7 +145,7 @@ abstract class KDispatcherResponseAbstract extends KControllerResponse implement
      * @param mixed  $content   The content
      * @param string $type      The content type
      * @throws \UnexpectedValueException If the content is not a string are cannot be casted to a string.
-     * @return HttpMessage
+     * @return KHttpMessage
      */
     public function setContent($content, $type = null)
     {

--- a/code/libraries/joomlatools/library/http/message/headers.php
+++ b/code/libraries/joomlatools/library/http/message/headers.php
@@ -99,12 +99,16 @@ class KHttpMessageHeaders extends KObjectArray
      */
     public function set($key, $values, $replace = true)
     {
-        $key = strtr(strtolower($key), '_', '-');
+        //Keys cannot be numeric, eg status code returned by get_headers($url, true)
+        if(!is_numeric($key))
+        {
+            $key = strtr(strtolower($key), '_', '-');
 
-        if ($replace === true || !isset($this[$key])) {
-            $this->_data[$key] = array($values);
-        } else {
-            $this->_data[$key] = array_merge($this->_data[$key], array($values));
+            if ($replace === true || !isset($this[$key])) {
+                $this->_data[$key] = array($values);
+            } else {
+                $this->_data[$key] = array_merge($this->_data[$key], array($values));
+            }
         }
 
         return $this;

--- a/code/libraries/joomlatools/library/http/message/interface.php
+++ b/code/libraries/joomlatools/library/http/message/interface.php
@@ -53,7 +53,7 @@ interface KHttpMessageInterface
      * @param mixed  $content   The content
      * @param string $type      The content type
      * @throws UnexpectedValueException If the content is not a string are cannot be casted to a string.
-     * @return HttpMessage
+     * @return KHttpMessage
      */
     public function setContent($content, $type = null);
 
@@ -78,6 +78,22 @@ interface KHttpMessageInterface
      * @return string Character set
      */
     public function getContentType();
+
+    /**
+     * Return the message format
+     *
+     * @return  string  The message format NULL if no format could be found
+     */
+    public function getFormat();
+
+    /**
+     * Sets a format
+     *
+     * @param string $format The format
+     * @throws UnexpectedValueException If the format hasn't been registered.
+     * @return KHttpMessage
+     */
+    public function setFormat($format);
 
     /**
      * Render the message as a string

--- a/code/libraries/joomlatools/library/http/request/request.php
+++ b/code/libraries/joomlatools/library/http/request/request.php
@@ -81,7 +81,7 @@ class KHttpRequest extends KHttpMessage implements KHttpRequestInterface
      * Set the header parameters
      *
      * @param  array $headers
-     * @return HttpRequest
+     * @return KHttpRequest
      */
     public function setHeaders($headers)
     {
@@ -94,7 +94,7 @@ class KHttpRequest extends KHttpMessage implements KHttpRequestInterface
      *
      * @param  string $method
      * @throws InvalidArgumentException
-     * @return HttpRequest
+     * @return KHttpRequest
      */
     public function setMethod($method)
     {
@@ -122,7 +122,7 @@ class KHttpRequest extends KHttpMessage implements KHttpRequestInterface
      * Set the url for this request
      *
      * @param string|array  $url Part(s) of an URL in form of a string or associative array like parse_url() returns
-     * @return HttpRequest
+     * @return KHttpRequest
      */
     public function setUrl($url)
     {

--- a/code/libraries/joomlatools/library/http/response/interface.php
+++ b/code/libraries/joomlatools/library/http/response/interface.php
@@ -150,7 +150,7 @@ interface KHttpResponseInterface extends KHttpMessageInterface
      *
      * @link https://tools.ietf.org/html/rfc2616#section-14.9.3
      * @param integer $max_age The max age of the response in seconds
-     * @return HttpResponse
+     * @return KHttpResponseInterface
      */
     public function setMaxAge($max_age);
 

--- a/code/libraries/joomlatools/library/http/response/response.php
+++ b/code/libraries/joomlatools/library/http/response/response.php
@@ -33,13 +33,6 @@ class KHttpResponse extends KHttpMessage implements KHttpResponseInterface
     protected $_status_message;
 
     /**
-     * The response content type
-     *
-     * @var string Content type
-     */
-    protected $_content_type;
-
-    /**
      * The response max age
      *
      * @var int Max age in seconds
@@ -247,37 +240,6 @@ class KHttpResponse extends KHttpMessage implements KHttpResponseInterface
         }
 
         return $message;
-    }
-
-    /**
-     * Sets the response content type
-     *
-     * @see http://tools.ietf.org/html/rfc2616#section-14.17
-     *
-     * @param string $type Content type
-     * @return KHttpResponse
-     */
-    public function setContentType($type)
-    {
-        if($type)
-        {
-            $this->_content_type = $type;
-            $this->_headers->set('Content-Type', array($type => array('charset' => 'utf-8')));
-        }
-
-        return $this;
-    }
-
-    /**
-     * Retrieves the response content type
-     *
-     * @link http://tools.ietf.org/html/rfc2616#section-14.17
-     *
-     * @return string Character set
-     */
-    public function getContentType()
-    {
-        return $this->_content_type;
     }
 
     /**


### PR DESCRIPTION
This PR moves the http format API into KHttpMessage and consolidates the http content type handling. This change allows for format negotiation in case a HttpResponse object is used directly. 