### PR TITLE
Add support for s-maxage

### DIFF
--- a/code/libraries/joomlatools/library/dispatcher/behavior/cacheable.php
+++ b/code/libraries/joomlatools/library/dispatcher/behavior/cacheable.php
@@ -34,7 +34,8 @@ class KDispatcherBehaviorCacheable extends KControllerBehaviorAbstract
             'priority' => self::PRIORITY_LOW,
             'cache'         => true,
             'cache_private' => false,
-            'cache_time'    => 0, //must revalidate
+            'cache_time'         => 0, //must revalidate
+            'cache_time_shared'  => 0, //must revalidate proxy
         ));
 
         parent::_initialize($config);
@@ -53,7 +54,9 @@ class KDispatcherBehaviorCacheable extends KControllerBehaviorAbstract
         parent::onMixin($mixer);
 
         //Set max age default
-        $this->getMixer()->getResponse()->setMaxAge($this->getConfig()->cache_time);
+        if($this->isCacheable()) {
+            $this->getMixer()->getResponse()->setMaxAge($this->getConfig()->cache_time, $this->getConfig()->cache_time_shared);
+        }
     }
 
     /**
@@ -121,18 +124,14 @@ class KDispatcherBehaviorCacheable extends KControllerBehaviorAbstract
      */
     protected function _getCacheControl()
     {
-        $cache = array();
         $response = $this->getResponse();
+        $cache    = $response->getCacheControl();
 
         if($response->getUser()->isAuthentic()) {
-            $cache = array('private');
+            $cache[] = 'private';
         } else {
-            $cache = array('public');
+            $cache[] = 'public';
         }
-
-        if(0 == $cache['max-age'] = $response->getMaxAge()) {
-            $cache[] = 'no-cache';
-        };
 
         return $cache;
     }

--- a/code/libraries/joomlatools/library/http/message/headers.php
+++ b/code/libraries/joomlatools/library/http/message/headers.php
@@ -167,16 +167,13 @@ class KHttpMessageHeaders extends KObjectArray
     }
 
     /**
-     * Returns the headers as a string.
+     * Returns the headers as an array
      *
-     * @return string
+     * @return array An associative array
      */
-    public function toString()
+    public function toArray()
     {
-        $headers = $this->_data;
-        $content = '';
-
-        ksort($headers);
+        $headers = array();
 
         //Method to implode header parameters
         $implode = function($parameters)
@@ -204,8 +201,9 @@ class KHttpMessageHeaders extends KObjectArray
             return $value = implode($results, ', ');
         };
 
-        //Serialise the headers to a string
-        foreach ($headers as $name => $values)
+        //Serialise the headers to an array
+        ksort($this->_data);
+        foreach ($this->_data as $name => $values)
         {
             $name    = implode('-', array_map('ucfirst', explode('-', $name)));
             $results = array();
@@ -220,8 +218,26 @@ class KHttpMessageHeaders extends KObjectArray
             }
 
             if ($value = implode($results, ', ')) {
-                $content .= sprintf("%s %s\r\n", $name.':', $value);
+                $headers[$name] = $value;
             }
+        }
+
+        return $headers;
+    }
+
+    /**
+     * Returns the headers as a string.
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        $headers = $this->toArray();
+        $content = '';
+
+        //Serialise the headers to a string
+        foreach ($headers as $name => $value) {
+            $content .= sprintf("%s %s\r\n", $name.':', $value);
         }
 
         return $content;

--- a/code/libraries/joomlatools/library/http/message/interface.php
+++ b/code/libraries/joomlatools/library/http/message/interface.php
@@ -96,6 +96,13 @@ interface KHttpMessageInterface
     public function setFormat($format);
 
     /**
+     * Returns the headers as an array
+     *
+     * @return array An associative array
+     */
+    public function toArray();
+
+    /**
      * Render the message as a string
      *
      * @return string

--- a/code/libraries/joomlatools/library/http/message/interface.php
+++ b/code/libraries/joomlatools/library/http/message/interface.php
@@ -96,13 +96,6 @@ interface KHttpMessageInterface
     public function setFormat($format);
 
     /**
-     * Returns the headers as an array
-     *
-     * @return array An associative array
-     */
-    public function toArray();
-
-    /**
      * Render the message as a string
      *
      * @return string

--- a/code/libraries/joomlatools/library/http/response/interface.php
+++ b/code/libraries/joomlatools/library/http/response/interface.php
@@ -149,15 +149,20 @@ interface KHttpResponseInterface extends KHttpMessageInterface
      * the next 60 seconds.
      *
      * @link https://tools.ietf.org/html/rfc2616#section-14.9.3
-     * @param integer $max_age The max age of the response in seconds
-     * @return KHttpResponseInterface
+     * @param integer $max_age       The number of seconds after which the response should no longer be considered fresh.
+     * @param integer $share_max_age The number of seconds after which the response should no longer be considered fresh by shared caches.
+     * @return KHttpResponse
      */
-    public function setMaxAge($max_age);
+    public function setMaxAge($max_age, $shared_max_age = null);
 
     /**
      * Get the max age
      *
-     * It returns 0 when no max age can be established.
+     * Returns the number of seconds after the time specified in the response's Date header when the response should no
+     * longer be considered fresh.
+     *
+     * First, it checks for a s-maxage directive, then a max-age directive. It returns null when no maximum age can be
+     * established.
      *
      * @link https://tools.ietf.org/html/rfc2616#section-14.9.3
      * @return integer Number of seconds

--- a/code/libraries/joomlatools/library/http/response/response.php
+++ b/code/libraries/joomlatools/library/http/response/response.php
@@ -32,12 +32,6 @@ class KHttpResponse extends KHttpMessage implements KHttpResponseInterface
      */
     protected $_status_message;
 
-    /**
-     * The response max age
-     *
-     * @var int Max age in seconds
-     */
-    protected $_max_age;
 
     // [Successful 2xx]
     const OK                        = 200;
@@ -403,31 +397,49 @@ class KHttpResponse extends KHttpMessage implements KHttpResponseInterface
      * the next 60 seconds.
      *
      * @link https://tools.ietf.org/html/rfc2616#section-14.9.3
-     * @param integer $max_age The max age of the response in seconds
+     * @param integer $max_age       The number of seconds after which the response should no longer be considered fresh.
+     * @param integer $share_max_age The number of seconds after which the response should no longer be considered fresh by shared caches.
      * @return KHttpResponse
      */
-    public function setMaxAge($max_age)
+    public function setMaxAge($max_age, $shared_max_age = null)
     {
-        $this->_max_age = $max_age;
+        $cache_control = $this->getCacheControl();
+
+        $cache_control['max-age'] = (int) $max_age;
+
+        if(!is_null($shared_max_age) && $shared_max_age > $max_age) {
+            $cache_control['s-maxage'] = (int) $shared_max_age;
+        }
+
+        $this->_headers->set('Cache-Control', $cache_control);
+
         return $this;
     }
 
     /**
      * Get the max age
      *
-     * It returns 0 when no max age can be established.
+     * Returns the number of seconds after the time specified in the response's Date header when the response should no
+     * longer be considered fresh.
+     *
+     * First, it checks for a s-maxage directive, then a max-age directive. It returns null when no maximum age can be
+     * established.
      *
      * @link https://tools.ietf.org/html/rfc2616#section-14.9.3
      * @return integer Number of seconds
      */
     public function getMaxAge()
     {
+        $result = 0;
+
         $cache_control = $this->getCacheControl();
 
         if (isset($cache_control['max-age'])) {
             $result = $cache_control['max-age'];
-        } else {
-            $result = (int) $this->_max_age;
+        }
+
+        if (isset($cache_control['s-maxage'])) {
+            $result = $cache_control['s-maxage'];
         }
 
         return (int) $result;
@@ -449,12 +461,15 @@ class KHttpResponse extends KHttpMessage implements KHttpResponseInterface
 
         foreach ($values as $key => $value)
         {
-            $parts = explode('=', $value);
-
-            if (count($parts) > 1)
+            if(is_string($value))
             {
-                unset($values[$key]);
-                $values[trim($parts[0])] = trim($parts[1]);
+                $parts = explode('=', $value);
+
+                if (count($parts) > 1)
+                {
+                    unset($values[$key]);
+                    $values[trim($parts[0])] = trim($parts[1]);
+                }
             }
         }
 


### PR DESCRIPTION
This PR adds an optional additional shared_max_age parameter to the `KHttpResponse::setMaxAge()` method. If the shared max age value is larger then the max age value it will be set in the cache control [s-maxage directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#Expiration). 

The `KHttpResponse::getMaxAge()` method now returns the `s-maxage` if it's defined and falls back to the max-age, or 0 if no max age is defined.

A new  `cache_time_shared` config option has been added to KDispatcherBehaviorCacheable  to allow setting the s-maxage cache control directive.