### PR TITLE
Fix format handling

### DIFF
--- a/code/libraries/joomlatools/component/koowa/dispatcher/behavior/decoratable.php
+++ b/code/libraries/joomlatools/component/koowa/dispatcher/behavior/decoratable.php
@@ -60,12 +60,11 @@ class ComKoowaDispatcherBehaviorDecoratable extends KControllerBehaviorAbstract
     protected function _beforeSend(KDispatcherContextInterface $context)
     {
         $response = $context->getResponse();
-        $request  = $context->getRequest();
 
         if(!$response->isDownloadable() && !$response->isRedirect())
         {
             //Render the page
-            $result = $this->getObject('com:koowa.controller.page',  array('response' => $response, 'request' => $request))
+            $result = $this->getObject('com:koowa.controller.page',  array('response' => $response))
                 ->layout($this->getDecorator())
                 ->render();
 

--- a/code/libraries/joomlatools/component/koowa/dispatcher/behavior/decoratable.php
+++ b/code/libraries/joomlatools/component/koowa/dispatcher/behavior/decoratable.php
@@ -60,11 +60,12 @@ class ComKoowaDispatcherBehaviorDecoratable extends KControllerBehaviorAbstract
     protected function _beforeSend(KDispatcherContextInterface $context)
     {
         $response = $context->getResponse();
+        $request  = $context->getRequest();
 
         if(!$response->isDownloadable() && !$response->isRedirect())
         {
             //Render the page
-            $result = $this->getObject('com:koowa.controller.page',  array('response' => $response))
+            $result = $this->getObject('com:koowa.controller.page',  array('response' => $response, 'request' => $request))
                 ->layout($this->getDecorator())
                 ->render();
 

--- a/code/libraries/joomlatools/library/controller/request/request.php
+++ b/code/libraries/joomlatools/library/controller/request/request.php
@@ -43,9 +43,6 @@ class KControllerRequest extends KHttpRequest implements KControllerRequestInter
 
         //Set data parameters
         $this->setData($config->data);
-
-        //Set the format
-        $this->setFormat($config->format);
     }
 
     /**

--- a/code/libraries/joomlatools/library/controller/request/request.php
+++ b/code/libraries/joomlatools/library/controller/request/request.php
@@ -58,9 +58,38 @@ class KControllerRequest extends KHttpRequest implements KControllerRequestInter
         $config->append(array(
             'query'  => array(),
             'data'   => array(),
+            'format' => 'html',
         ));
 
         parent::_initialize($config);
+    }
+
+    /**
+     * Return the request format or mediatype
+     *
+     * Find the format by using following sequence :
+     *
+     * 1. Use the the 'format' request parameter
+     * 2. Use the URL path extension
+     * 3. Use the accept header with the highest quality apply the reverse format map to find the format.
+     *
+     * @param   bool    $mediatype Get the media type
+     * @return  string  The request format or NULL if no format could be found
+     */
+    public function getFormat($mediatype = false)
+    {
+        if (!isset($this->_format))
+        {
+            if(!$this->query->has('format')) {
+                $format = parent::getFormat() ?: $this->getConfig()->format;
+            } else {
+                $format = $this->query->get('format', 'word');
+            }
+
+            $this->_format = $format;
+        }
+
+        return $mediatype ? static::$_formats[$this->_format][0] : $this->_format;
     }
 
     /**

--- a/code/libraries/joomlatools/library/controller/request/request.php
+++ b/code/libraries/joomlatools/library/controller/request/request.php
@@ -61,7 +61,6 @@ class KControllerRequest extends KHttpRequest implements KControllerRequestInter
         $config->append(array(
             'query'  => array(),
             'data'   => array(),
-            'format' => 'html',
         ));
 
         parent::_initialize($config);

--- a/code/libraries/joomlatools/library/dispatcher/request/abstract.php
+++ b/code/libraries/joomlatools/library/dispatcher/request/abstract.php
@@ -229,7 +229,6 @@ abstract class KDispatcherRequestAbstract extends KControllerRequest implements 
             'cookies' => $_COOKIE,
             'files'   => $_FILES,
             'proxies' => array(),
-            'format'  => null,
         ));
 
         parent::_initialize($config);
@@ -744,44 +743,13 @@ abstract class KDispatcherRequestAbstract extends KControllerRequest implements 
     {
         if (!isset($this->_format))
         {
-            if(!$this->query->has('format'))
-            {
-                $format = pathinfo($this->getUrl()->getPath(), PATHINFO_EXTENSION);
-
-                if(empty($format) || !isset(static::$_formats[$format]))
-                {
-                    $format = 'html'; //define html default
-
-                    if ($this->_headers->has('Accept'))
-                    {
-                        $accept  = $this->_headers->get('Accept');
-                        $formats = $this->_parseAccept($accept);
-
-                        /**
-                         * If the browser is requested text/html serve it at all times
-                         *
-                         * @hotfix #409 : Android 2.3 requesting application/xml
-                         */
-                        if (!isset($formats['text/html']))
-                        {
-                            //Get the highest quality format
-                            $mime_type = key($formats);
-
-                            foreach (static::$_formats as $value => $mime_types)
-                            {
-                                if (in_array($mime_type, (array)$mime_types)) {
-                                    $format = $value;
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                }
+            if(!$this->query->has('format')) {
+                $format = parent::getFormat() ?: 'html';
+            } else {
+                $format = $this->query->get('format', 'word');
             }
-            else $format = $this->query->get('format', 'word');
 
             $this->_format = $format;
-            $this->setFormat($format);
         }
 
         return $mediatype ? static::$_formats[$this->_format][0] : $this->_format;
@@ -1051,61 +1019,7 @@ abstract class KDispatcherRequestAbstract extends KControllerRequest implements 
         return parent::__get($name);
     }
 
-    /**
-     * Parses an accept header and returns an array (type => quality) of the accepted types, ordered by quality.
-     *
-     * @param string    $accept     The header to parse
-     * @param array     $defaults   The default values
-     * @return array
-     */
-    protected function _parseAccept($accept, array $defaults = NULL)
-    {
-        if (!empty($accept))
-        {
-            // Get all of the types
-            $types = explode(',', $accept);
 
-            foreach ($types as $type)
-            {
-                // Split the type into parts
-                $parts = explode(';', $type);
-
-                // Make the type only the MIME
-                $type = trim(array_shift($parts));
-
-                // Default quality is 1.0
-                $options = array('quality' => 1.0);
-
-                foreach ($parts as $part)
-                {
-                    // Prevent undefined $value notice below
-                    if (strpos($part, '=') === FALSE) {
-                        continue;
-                    }
-
-                    // Separate the key and value
-                    list ($key, $value) = explode('=', trim($part));
-
-                    switch ($key)
-                    {
-                        case 'q'       : $options['quality'] = (float) trim($value); break;
-                        case 'version' : $options['version'] = (float) trim($value); break;
-                    }
-                }
-
-                // Add the accept type and quality
-                $defaults[$type] = $options;
-            }
-        }
-
-        // Make sure that accepts is an array
-        $accepts = (array) $defaults;
-
-        // Order by quality
-        arsort($accepts);
-
-        return $accepts;
-    }
 
     /**
      * Deep clone of this instance

--- a/code/libraries/joomlatools/library/dispatcher/request/abstract.php
+++ b/code/libraries/joomlatools/library/dispatcher/request/abstract.php
@@ -728,34 +728,6 @@ abstract class KDispatcherRequestAbstract extends KControllerRequest implements 
     }
 
     /**
-     * Return the request format or mediatype
-     *
-     * Find the format by using following sequence :
-     *
-     * 1. Use the the 'format' request parameter
-     * 2. Use the URL path extension
-     * 3. Use the accept header with the highest quality apply the reverse format map to find the format.
-     *
-     * @param   bool    $mediatype Get the media type
-     * @return  string  The request format or NULL if no format could be found
-     */
-    public function getFormat($mediatype = false)
-    {
-        if (!isset($this->_format))
-        {
-            if(!$this->query->has('format')) {
-                $format = parent::getFormat() ?: 'html';
-            } else {
-                $format = $this->query->get('format', 'word');
-            }
-
-            $this->_format = $format;
-        }
-
-        return $mediatype ? static::$_formats[$this->_format][0] : $this->_format;
-    }
-
-    /**
      * Gets a list of languages acceptable by the client browser.
      *
      * @return array Languages ordered in the user browser preferences

--- a/code/libraries/joomlatools/library/dispatcher/request/abstract.php
+++ b/code/libraries/joomlatools/library/dispatcher/request/abstract.php
@@ -743,15 +743,11 @@ abstract class KDispatcherRequestAbstract extends KControllerRequest implements 
     {
         if (!isset($this->_format))
         {
-            if($this->isSafe())
-            {
-                if(!$this->query->has('format')) {
-                    $format = parent::getFormat() ?: 'html';
-                } else {
-                    $format = $this->query->get('format', 'word');
-                }
+            if(!$this->query->has('format')) {
+                $format = parent::getFormat() ?: 'html';
+            } else {
+                $format = $this->query->get('format', 'word');
             }
-            else $format = parent::getFormat();
 
             $this->_format = $format;
         }

--- a/code/libraries/joomlatools/library/dispatcher/request/abstract.php
+++ b/code/libraries/joomlatools/library/dispatcher/request/abstract.php
@@ -743,11 +743,15 @@ abstract class KDispatcherRequestAbstract extends KControllerRequest implements 
     {
         if (!isset($this->_format))
         {
-            if(!$this->query->has('format')) {
-                $format = parent::getFormat() ?: 'html';
-            } else {
-                $format = $this->query->get('format', 'word');
+            if($this->isSafe())
+            {
+                if(!$this->query->has('format')) {
+                    $format = parent::getFormat() ?: 'html';
+                } else {
+                    $format = $this->query->get('format', 'word');
+                }
             }
+            else $format = parent::getFormat();
 
             $this->_format = $format;
         }

--- a/code/libraries/joomlatools/library/http/message/message.php
+++ b/code/libraries/joomlatools/library/http/message/message.php
@@ -255,23 +255,6 @@ abstract class KHttpMessage extends KObject implements KHttpMessageInterface
      */
     public function getFormat()
     {
-        $result = null;
-
-        if(!$this->_format)
-        {
-            foreach (static::$_formats as $value => $media_types)
-            {
-                if($media_type = $this->getContentType())
-                {
-                    if (in_array($media_type, (array)$media_types))
-                    {
-                        $this->_format = $value;
-                        break;
-                    }
-                }
-            }
-        }
-
         return $this->_format;
     }
 

--- a/code/libraries/joomlatools/library/http/message/message.php
+++ b/code/libraries/joomlatools/library/http/message/message.php
@@ -46,6 +46,13 @@ abstract class KHttpMessage extends KObject implements KHttpMessageInterface
     protected $_content_type;
 
     /**
+     * The message format
+     *
+     * @var string
+     */
+    protected $_format;
+
+    /**
      * Mediatype to format mappings
      *
      * @var array
@@ -250,18 +257,22 @@ abstract class KHttpMessage extends KObject implements KHttpMessageInterface
     {
         $result = null;
 
-        foreach (static::$_formats as $value => $media_types)
+        if(!$this->_format)
         {
-            $media_type = $this->getContentType();
-
-            if (in_array($media_type, (array)$media_types))
+            foreach (static::$_formats as $value => $media_types)
             {
-                $result = $value;
-                break;
+                if($media_type = $this->getContentType())
+                {
+                    if (in_array($media_type, (array)$media_types))
+                    {
+                        $this->_format = $value;
+                        break;
+                    }
+                }
             }
         }
 
-        return $result;
+        return $this->_format;
     }
 
     /**
@@ -279,7 +290,7 @@ abstract class KHttpMessage extends KObject implements KHttpMessageInterface
                 throw new UnexpectedValueException('Unregistered format: "' . $format . '" given.');
             }
 
-            $this->setContentType(static::$_formats[$format][0]);
+            $this->_format = $format;
         }
 
         return $this;

--- a/code/libraries/joomlatools/library/http/request/request.php
+++ b/code/libraries/joomlatools/library/http/request/request.php
@@ -95,6 +95,8 @@ class KHttpRequest extends KHttpMessage implements KHttpRequestInterface
 
             if(empty($format) || !isset(static::$_formats[$format]))
             {
+                $format = null; //reset
+
                 if ($this->_headers->has('Accept'))
                 {
                     $accept = $this->_headers->get('Accept');
@@ -118,7 +120,7 @@ class KHttpRequest extends KHttpMessage implements KHttpRequestInterface
                             }
                         }
                     }
-                    else $format = 'html';
+                    else $format = 'html'; //html requested
                 }
             }
 

--- a/code/libraries/joomlatools/library/http/request/request.php
+++ b/code/libraries/joomlatools/library/http/request/request.php
@@ -78,6 +78,56 @@ class KHttpRequest extends KHttpMessage implements KHttpRequestInterface
     }
 
     /**
+     * Return the request format or mediatype
+     *
+     * Find the format by using following sequence :
+     *
+     * 1. Use the URL path extension
+     * 2. Use the accept header with the highest quality apply the reverse format map to find the format.
+     *
+     * @return  string  The request format or NULL if no format could be found
+     */
+    public function getFormat()
+    {
+        if (!isset($this->_format))
+        {
+            $format = pathinfo($this->getUrl()->getPath(), PATHINFO_EXTENSION);
+
+            if(empty($format) || !isset(static::$_formats[$format]))
+            {
+                if ($this->_headers->has('Accept'))
+                {
+                    $accept  = $this->_headers->get('Accept');
+                    $formats = $this->_parseAccept($accept);
+
+                    /**
+                     * If the browser is requested text/html serve it at all times
+                     *
+                     * @hotfix #409 : Android 2.3 requesting application/xml
+                     */
+                    if (!isset($formats['text/html']))
+                    {
+                        //Get the highest quality format
+                        $mime_type = key($formats);
+
+                        foreach (static::$_formats as $value => $mime_types)
+                        {
+                            if (in_array($mime_type, (array)$mime_types)) {
+                                $format = $value;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
+            $this->_format = $format;
+        }
+
+        return $this->_format;
+    }
+
+    /**
      * Set the header parameters
      *
      * @param  array $headers
@@ -303,5 +353,61 @@ class KHttpRequest extends KHttpMessage implements KHttpRequestInterface
         if($this->_url instanceof KHttpUrl) {
             $this->_url = clone $this->_url;
         }
+    }
+
+    /**
+     * Parses an accept header and returns an array (type => quality) of the accepted types, ordered by quality.
+     *
+     * @param string    $accept     The header to parse
+     * @param array     $defaults   The default values
+     * @return array
+     */
+    protected function _parseAccept($accept, array $defaults = NULL)
+    {
+        if (!empty($accept))
+        {
+            // Get all of the types
+            $types = explode(',', $accept);
+
+            foreach ($types as $type)
+            {
+                // Split the type into parts
+                $parts = explode(';', $type);
+
+                // Make the type only the MIME
+                $type = trim(array_shift($parts));
+
+                // Default quality is 1.0
+                $options = array('quality' => 1.0);
+
+                foreach ($parts as $part)
+                {
+                    // Prevent undefined $value notice below
+                    if (strpos($part, '=') === FALSE) {
+                        continue;
+                    }
+
+                    // Separate the key and value
+                    list ($key, $value) = explode('=', trim($part));
+
+                    switch ($key)
+                    {
+                        case 'q'       : $options['quality'] = (float) trim($value); break;
+                        case 'version' : $options['version'] = (float) trim($value); break;
+                    }
+                }
+
+                // Add the accept type and quality
+                $defaults[$type] = $options;
+            }
+        }
+
+        // Make sure that accepts is an array
+        $accepts = (array) $defaults;
+
+        // Order by quality
+        arsort($accepts);
+
+        return $accepts;
     }
 }

--- a/code/libraries/joomlatools/library/http/request/request.php
+++ b/code/libraries/joomlatools/library/http/request/request.php
@@ -118,6 +118,7 @@ class KHttpRequest extends KHttpMessage implements KHttpRequestInterface
                             }
                         }
                     }
+                    else $format = 'html';
                 }
             }
 

--- a/code/libraries/joomlatools/library/http/request/request.php
+++ b/code/libraries/joomlatools/library/http/request/request.php
@@ -91,35 +91,41 @@ class KHttpRequest extends KHttpMessage implements KHttpRequestInterface
     {
         if (!isset($this->_format))
         {
-            $format = pathinfo($this->getUrl()->getPath(), PATHINFO_EXTENSION);
-
-            if(empty($format) || !isset(static::$_formats[$format]))
+            //GET request
+            if($this->isSafe())
             {
-                if ($this->_headers->has('Accept'))
+                $format = pathinfo($this->getUrl()->getPath(), PATHINFO_EXTENSION);
+
+                if(empty($format) || !isset(static::$_formats[$format]))
                 {
-                    $accept  = $this->_headers->get('Accept');
-                    $formats = $this->_parseAccept($accept);
-
-                    /**
-                     * If the browser is requested text/html serve it at all times
-                     *
-                     * @hotfix #409 : Android 2.3 requesting application/xml
-                     */
-                    if (!isset($formats['text/html']))
+                    if ($this->_headers->has('Accept'))
                     {
-                        //Get the highest quality format
-                        $mime_type = key($formats);
+                        $accept  = $this->_headers->get('Accept');
+                        $formats = $this->_parseAccept($accept);
 
-                        foreach (static::$_formats as $value => $mime_types)
+                        /**
+                         * If the browser is requested text/html serve it at all times
+                         *
+                         * @hotfix #409 : Android 2.3 requesting application/xml
+                         */
+                        if (!isset($formats['text/html']))
                         {
-                            if (in_array($mime_type, (array)$mime_types)) {
-                                $format = $value;
-                                break;
+                            //Get the highest quality format
+                            $mime_type = key($formats);
+
+                            foreach (static::$_formats as $value => $mime_types)
+                            {
+                                if (in_array($mime_type, (array)$mime_types)) {
+                                    $format = $value;
+                                    break;
+                                }
                             }
                         }
                     }
                 }
             }
+            //POST/PUT request
+            else $format = parent::getFormat();
 
             $this->_format = $format;
         }

--- a/code/libraries/joomlatools/library/http/request/request.php
+++ b/code/libraries/joomlatools/library/http/request/request.php
@@ -91,41 +91,35 @@ class KHttpRequest extends KHttpMessage implements KHttpRequestInterface
     {
         if (!isset($this->_format))
         {
-            //GET request
-            if($this->isSafe())
+            $format = pathinfo($this->getUrl()->getPath(), PATHINFO_EXTENSION);
+
+            if(empty($format) || !isset(static::$_formats[$format]))
             {
-                $format = pathinfo($this->getUrl()->getPath(), PATHINFO_EXTENSION);
-
-                if(empty($format) || !isset(static::$_formats[$format]))
+                if ($this->_headers->has('Accept'))
                 {
-                    if ($this->_headers->has('Accept'))
+                    $accept = $this->_headers->get('Accept');
+                    $formats = $this->_parseAccept($accept);
+
+                    /**
+                     * If the browser is requested text/html serve it at all times
+                     *
+                     * @hotfix #409 : Android 2.3 requesting application/xml
+                     */
+                    if (!isset($formats['text/html']))
                     {
-                        $accept  = $this->_headers->get('Accept');
-                        $formats = $this->_parseAccept($accept);
+                        //Get the highest quality format
+                        $mime_type = key($formats);
 
-                        /**
-                         * If the browser is requested text/html serve it at all times
-                         *
-                         * @hotfix #409 : Android 2.3 requesting application/xml
-                         */
-                        if (!isset($formats['text/html']))
+                        foreach (static::$_formats as $value => $mime_types)
                         {
-                            //Get the highest quality format
-                            $mime_type = key($formats);
-
-                            foreach (static::$_formats as $value => $mime_types)
-                            {
-                                if (in_array($mime_type, (array)$mime_types)) {
-                                    $format = $value;
-                                    break;
-                                }
+                            if (in_array($mime_type, (array)$mime_types)) {
+                                $format = $value;
+                                break;
                             }
                         }
                     }
                 }
             }
-            //POST/PUT request
-            else $format = parent::getFormat();
 
             $this->_format = $format;
         }

--- a/code/libraries/joomlatools/library/http/response/response.php
+++ b/code/libraries/joomlatools/library/http/response/response.php
@@ -173,6 +173,33 @@ class KHttpResponse extends KHttpMessage implements KHttpResponseInterface
     }
 
     /**
+     * Return the message format
+     *
+     * @return  string  The message format NULL if no format could be found
+     */
+    public function getFormat()
+    {
+        $result = null;
+
+        if(!$this->_format)
+        {
+            foreach (static::$_formats as $value => $media_types)
+            {
+                if($media_type = $this->getContentType())
+                {
+                    if (in_array($media_type, (array)$media_types))
+                    {
+                        $this->_format = $value;
+                        break;
+                    }
+                }
+            }
+        }
+
+        return $this->_format;
+    }
+
+    /**
      * Set the header parameters
      *
      * @param  array $headers

--- a/code/libraries/joomlatools/library/http/response/response.php
+++ b/code/libraries/joomlatools/library/http/response/response.php
@@ -173,7 +173,7 @@ class KHttpResponse extends KHttpMessage implements KHttpResponseInterface
     }
 
     /**
-     * Return the message format
+     * Return the message format from the content type
      *
      * @return  string  The message format NULL if no format could be found
      */
@@ -197,6 +197,22 @@ class KHttpResponse extends KHttpMessage implements KHttpResponseInterface
         }
 
         return $this->_format;
+    }
+
+    /**
+     * Sets a format and set the content type
+     *
+     * @param string $format The format
+     * @throws UnexpectedValueException If the format hasn't been registered.
+     * @return KHttpMessage
+     */
+    public function setFormat($format)
+    {
+        parent::setFormat($format);
+
+        $this->setContentType(static::$_formats[$format][0]);
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
This PR makes format handling consistent across request and response.

### 1. Request 

Format handling for the request has been moved to KHttpRequest, the format is negotiated based on the url extension and if no extension exists the accept header is used.

The format handling is extended in the dispatcher, to also allow a format to be defined through the 'format' query variable.

### 2. Response

Format handling for the response has been moved to KHttpResponse, the format is retrieved from the content type header. If the format is changed in the response the content type is also changed.

### Notes

- A default format is only set to 'html' through the dispatcher response, default formats are not set elsewhere. 