### PR TITLE
Improve debug implementation

### DIFF
--- a/code/libraries/joomlatools/component/koowa/resources/config/bootstrapper.php
+++ b/code/libraries/joomlatools/component/koowa/resources/config/bootstrapper.php
@@ -33,6 +33,7 @@ return array(
 
         'template.engine.factory' => array(
             'cache'        => JDEBUG ? false : true,
+            'debug'        => JDEBUG ? true  : false,
             'cache_path'   => JPATH_ADMINISTRATOR.'/cache/koowa.templates'
         ),
 

--- a/code/libraries/joomlatools/library/resources/assets/js/dumper.js
+++ b/code/libraries/joomlatools/library/resources/assets/js/dumper.js
@@ -14,7 +14,7 @@ function toggle_trace() {
 
     // Iterate through them
     for( var i = 0; i < dumpees.length; i++ ) {
-        var next = dumpees[i].nextSibling;
+        var next = dumpees[i].nextElementSibling;
         apollo.addClass(dumpees[i], 'koowa-collapsed');
         apollo.addClass(next, 'koowa-collapsed');
 
@@ -25,7 +25,7 @@ function toggle_trace() {
 
     // The fuction for the link
     function useItem(el){
-        var next = el.nextSibling;
+        var next = el.nextElementSibling;
         if ( apollo.hasClass(next, 'koowa-collapsed') ) {
             apollo.removeClass(el, 'koowa-collapsed');
             apollo.removeClass(next, 'koowa-collapsed');

--- a/code/libraries/joomlatools/library/template/engine/abstract.php
+++ b/code/libraries/joomlatools/library/template/engine/abstract.php
@@ -94,6 +94,7 @@ abstract class KTemplateEngineAbstract extends KTemplateAbstract implements KTem
                 'json'      => 'json_encode',
                 'format'    => 'sprintf',
                 'replace'   => 'strtr',
+                'debug'     => array($this, 'isDebug'),
             ),
         ));
 

--- a/code/libraries/joomlatools/library/template/helper/debug.php
+++ b/code/libraries/joomlatools/library/template/helper/debug.php
@@ -495,7 +495,7 @@ class KTemplateHelperDebug extends KTemplateHelperBehavior
                     $collapsed = $level ? count($var) >= 7 : false;
 
                     $result .= '<span class="koowa-toggle' . ($collapsed ? ' koowa-collapsed' : '') . '">'  . count($var) . ')</span>';
-                    $result .= '<div' . ($collapsed ? ' class="koowa-collapsed"' : '') . '>';
+                    $result .= '<span' . ($collapsed ? ' class="koowa-collapsed"' : '') . '>';
 
                     $var[$marker] = true;
 
@@ -510,7 +510,7 @@ class KTemplateHelperDebug extends KTemplateHelperBehavior
                     }
 
                     unset($var[$marker]);
-                    $result .= '</div>';
+                    $result .= '</span>';
                 }
                 else $result .= count($var) . ") [ ... ]\n";
             }
@@ -596,7 +596,7 @@ class KTemplateHelperDebug extends KTemplateHelperBehavior
                     $collapsed = false;//$level ? count($var) >= 7 : false;
 
                     $result  = '<span class="koowa-toggle' . ($collapsed ? ' koowa-collapsed' : '') . '">' . $result . '</span>';
-                    $result .= '<div' . ($collapsed ? ' class="koowa-collapsed"' : '') . '>';
+                    $result .= '<span' . ($collapsed ? ' class="koowa-collapsed"' : '') . '>';
 
                     $list[] = $var;
 
@@ -615,7 +615,7 @@ class KTemplateHelperDebug extends KTemplateHelperBehavior
                     }
 
                     array_pop($list);
-                    $result .= '</div>';
+                    $result .= '</span>';
                 }
                 else $result .= ' { ... }'."\n";
             }
@@ -643,7 +643,7 @@ class KTemplateHelperDebug extends KTemplateHelperBehavior
         if (isset($config->resources[$type]))
         {
             $result  = '<span class="koowa-toggle koowa-collapsed">'.$result.'</span>';
-            $result .= '<div class="koowa-collapsed">';
+            $result .= '<span class="koowa-collapsed">';
 
             foreach (call_user_func($config->resources[$type], $var) as $key => $value)
             {
@@ -651,7 +651,7 @@ class KTemplateHelperDebug extends KTemplateHelperBehavior
                 $result .= '<span class="koowa-dump-key">' . $this->getTemplate()->escape($key) . "</span> => " . $this->_dumpVar($value, $config, $level + 1);
             }
 
-            $result .= '</div>';
+            $result .= '</span>';
 
             return $result;
         }


### PR DESCRIPTION
This PR fixes markup issues with the debug output ands a new debug() template method to be able to easily check if debug is enabled for templates or not.