### PR TITLE
Make template filters html5 compliant

### DIFF
--- a/code/libraries/joomlatools/library/template/filter/abstract.php
+++ b/code/libraries/joomlatools/library/template/filter/abstract.php
@@ -157,6 +157,6 @@ abstract class KTemplateFilterAbstract extends KObject implements KTemplateFilte
             }
         }
 
-        return implode(' ', $output);
+        return !empty($output) ? ' '.implode(' ', $output) : '';
     }
 }

--- a/code/libraries/joomlatools/library/template/filter/link.php
+++ b/code/libraries/joomlatools/library/template/filter/link.php
@@ -28,7 +28,7 @@ class KTemplateFilterLink extends KTemplateFilterTag
         $tags = '';
 
         $matches = array();
-        if(preg_match_all('#<link\ href="([^"]+)"(.*)\/>#siU', $text, $matches))
+        if(preg_match_all('#<link\s+href="([^"]+)"(.*)\/>#siU', $text, $matches))
         {
             foreach(array_unique($matches[1]) as $key => $match)
             {
@@ -59,7 +59,7 @@ class KTemplateFilterLink extends KTemplateFilterTag
     {
         $attribs = $this->buildAttributes($attribs);
 
-        $html = '<link '.$attribs.'/>'."\n";
+        $html = '<link'.$attribs.'/>'."\n";
         return $html;
     }
 }

--- a/code/libraries/joomlatools/library/template/filter/meta.php
+++ b/code/libraries/joomlatools/library/template/filter/meta.php
@@ -28,7 +28,7 @@ class KTemplateFilterMeta extends KTemplateFilterTag
         $tags = '';
 
         $matches = array();
-        if(preg_match_all('#<meta(.*)\/>#siU', $text, $matches))
+        if(preg_match_all('#<meta(?!\s+itemprop\s*)\s+(.*)\/>#siU', $text, $matches))
         {
             foreach($matches[1] as $key => $match)
             {

--- a/code/libraries/joomlatools/library/template/filter/meta.php
+++ b/code/libraries/joomlatools/library/template/filter/meta.php
@@ -28,16 +28,11 @@ class KTemplateFilterMeta extends KTemplateFilterTag
         $tags = '';
 
         $matches = array();
-        if(preg_match_all('#<meta\ content="([^"]+)"(.*)\/>#siU', $text, $matches))
+        if(preg_match_all('#<meta(.*)\/>#siU', $text, $matches))
         {
             foreach($matches[1] as $key => $match)
             {
-                //Set required attributes
-                $attribs = array(
-                    'content' => $match
-                );
-
-                $attribs = array_merge($this->parseAttributes( $matches[2][$key]), $attribs);
+                $attribs = $this->parseAttributes( $match);
                 $tags .= $this->_renderTag($attribs);
             }
 
@@ -58,7 +53,7 @@ class KTemplateFilterMeta extends KTemplateFilterTag
     {
         $attribs = $this->buildAttributes($attribs);
 
-        $html = '<meta '.$attribs.' />'."\n";
+        $html = '<meta'.$attribs.' />'."\n";
         return $html;
     }
 }

--- a/code/libraries/joomlatools/library/template/filter/script.php
+++ b/code/libraries/joomlatools/library/template/filter/script.php
@@ -42,11 +42,6 @@ class KTemplateFilterScript extends KTemplateFilterTag
                 );
 
                 $attribs = array_merge($this->parseAttributes( $matches[2][$key]), $attribs);
-
-                if(!isset($attribs['type'])) {
-                    $attribs['type'] = 'text/javascript';
-                };
-
                 $tags .= $this->_renderTag($attribs);
             }
 
@@ -60,11 +55,6 @@ class KTemplateFilterScript extends KTemplateFilterTag
             foreach($matches[2] as $key => $match)
             {
                 $attribs = $this->parseAttributes( $matches[1][$key]);
-
-                if(!isset($attribs['type'])) {
-                    $attribs['type'] = 'text/javascript';
-                };
-
                 $tags .= $this->_renderTag($attribs, $match);
             }
 
@@ -90,7 +80,7 @@ class KTemplateFilterScript extends KTemplateFilterTag
         {
             $attribs = $this->buildAttributes($attribs);
 
-            $html  = '<script '.$attribs.'>'."\n";
+            $html  = '<script'.$attribs.'>'."\n";
             $html .= trim($content);
             $html .= '</script>'."\n";
         }

--- a/code/libraries/joomlatools/library/template/filter/style.php
+++ b/code/libraries/joomlatools/library/template/filter/style.php
@@ -75,7 +75,7 @@ class KTemplateFilterStyle extends KTemplateFilterTag
         {
             $attribs = $this->buildAttributes($attribs);
 
-            $html  = '<style type="text/css" '.$attribs.'>'."\n";
+            $html  = '<style'.$attribs.'>'."\n";
             $html .= trim($content);
             $html .= '</style>'."\n";
         }
@@ -88,10 +88,10 @@ class KTemplateFilterStyle extends KTemplateFilterTag
             if($condition)
             {
                 $html  = '<!--['.$condition.']>';
-                $html .= '<link type="text/css" rel="stylesheet" href="'.$link.'" '.$attribs.' />'."\n";
+                $html .= '<link rel="stylesheet" href="'.$link.'" '.$attribs.' />'."\n";
                 $html .= '<![endif]-->';
             }
-            else $html  = '<link type="text/css" rel="stylesheet" href="'.$link.'" '.$attribs.' />'."\n";
+            else $html  = '<link rel="stylesheet" href="'.$link.'" '.$attribs.' />'."\n";
         }
 
         return $html;


### PR DESCRIPTION
This PR Html5 removes default type attributes in link and script tags and makes some regexes a bit more flexible. 