### PR TITLE
Event subscribers cannot define priority

### DIFF
--- a/code/libraries/joomlatools/component/koowa/event/subscriber/unauthorized.php
+++ b/code/libraries/joomlatools/component/koowa/event/subscriber/unauthorized.php
@@ -18,7 +18,7 @@ class ComKoowaEventSubscriberUnauthorized extends KEventSubscriberAbstract
     protected function _initialize(KObjectConfig $config)
     {
         $config->append(array(
-            'priority' => KEvent::PRIORITY_HIGH
+            'priority' => KEvent::PRIORITY_HIGHEST
         ));
 
         parent::_initialize($config);

--- a/code/libraries/joomlatools/library/event/publisher/exception.php
+++ b/code/libraries/joomlatools/library/event/publisher/exception.php
@@ -88,7 +88,7 @@ class KEventPublisherException extends KEventPublisherAbstract
      * @param   Exception           $exception  The exception to be published.
      * @param  array|Traversable    $attributes An associative array or a Traversable object
      * @param  mixed                $target     The event target
-     * @return  KEventException
+     * @return  bool
      */
     public function publishException(Exception $exception, $attributes = array(), $target = null)
     {
@@ -96,7 +96,15 @@ class KEventPublisherException extends KEventPublisherAbstract
         $event = new KEventException('onException', $attributes, $target);
         $event->setException($exception);
 
-        parent::publishEvent($event);
+        if(parent::publishEvent($event))
+        {
+            //Halt the exception handling if the exception event can no longer be propagated.
+            if(!$event->canPropagate()) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/code/libraries/joomlatools/library/event/subscriber/abstract.php
+++ b/code/libraries/joomlatools/library/event/subscriber/abstract.php
@@ -29,16 +29,51 @@ abstract class KEventSubscriberAbstract extends KObject implements KEventSubscri
     private $__publishers;
 
     /**
+     * The subscriber priority
+     *
+     * @var integer
+     */
+    protected $_priority;
+
+    /**
+     * Constructor.
+     *
+     * @param KObjectConfig $config  An optional ObjectConfig object with configuration options
+     */
+    public function __construct(KObjectConfig $config)
+    {
+        parent::__construct($config);
+
+        //Set the command priority
+        $this->_priority = $config->priority;
+    }
+
+    /**
+     * Initializes the options for the object
+     *
+     * Called from {@link __construct()} as a first step of object instantiation.
+     *
+     * @param  KObjectConfig $config A ObjectConfig object with configuration options
+     * @return void
+     */
+    protected function _initialize(KObjectConfig $config)
+    {
+        $config->append(array(
+            'priority'   => self::PRIORITY_NORMAL,
+        ));
+
+        parent::_initialize($config);
+    }
+
+    /**
      * Attach one or more listeners
      *
      * Event listeners always start with 'on' and need to be public methods.
      *
      * @param KEventPublisherInterface $publisher
-     * @param  integer                 $priority   The event priority, usually between 1 (high priority) and 5 (lowest),
-     *                                 default is 3 (normal)
      * @return array An array of public methods that have been attached
      */
-    public function subscribe(KEventPublisherInterface $publisher, $priority = KEvent::PRIORITY_NORMAL)
+    public function subscribe(KEventPublisherInterface $publisher)
     {
         $handle    = $publisher->getHandle();
         $listeners = [];
@@ -49,7 +84,7 @@ abstract class KEventSubscriberAbstract extends KObject implements KEventSubscri
 
             foreach ($listeners as $listener)
             {
-                $publisher->addListener($listener, array($this, $listener), $priority);
+                $publisher->addListener($listener, array($this, $listener), $this->getPriority());
                 $this->__publishers[$handle][] = $listener;
             }
         }
@@ -107,5 +142,15 @@ abstract class KEventSubscriberAbstract extends KObject implements KEventSubscri
         }
 
         return $listeners;
+    }
+
+    /**
+     * Get the priority of a subscriber
+     *
+     * @return  integer The subscriber priority
+     */
+    public function getPriority()
+    {
+        return $this->_priority;
     }
 }

--- a/code/libraries/joomlatools/library/event/subscriber/interface.php
+++ b/code/libraries/joomlatools/library/event/subscriber/interface.php
@@ -19,14 +19,21 @@
 interface KEventSubscriberInterface
 {
     /**
+     * Priority levels
+     */
+    const PRIORITY_HIGHEST = 1;
+    const PRIORITY_HIGH    = 2;
+    const PRIORITY_NORMAL  = 3;
+    const PRIORITY_LOW     = 4;
+    const PRIORITY_LOWEST  = 5;
+
+    /**
      * Register one or more listeners
      *
      * @param KEventPublisherInterface $publisher
-     * @param  integer                 $priority   The event priority, usually between 1 (high priority) and 5 (lowest),
-     *                                 default is 3 (normal)
      * @@return array An array of public methods that have been attached
      */
-    public function subscribe(KEventPublisherInterface $publisher, $priority = KEventInterface::PRIORITY_NORMAL);
+    public function subscribe(KEventPublisherInterface $publisher);
 
     /**
      * Unsubscribe all previously registered listeners
@@ -50,4 +57,11 @@ interface KEventSubscriberInterface
      * @return array
      */
     public static function getEventListeners();
+
+    /**
+     * Get the priority of the subscriber
+     *
+     * @return	integer The subscriber priority
+     */
+    public function getPriority();
 }

--- a/code/libraries/joomlatools/plugin/koowa/subscriber.php
+++ b/code/libraries/joomlatools/plugin/koowa/subscriber.php
@@ -23,6 +23,43 @@ abstract class PlgKoowaSubscriber extends PlgKoowaAbstract implements KEventSubs
     private $__publishers;
 
     /**
+     * The subscriber priority
+     *
+     * @var integer
+     */
+    protected $_priority;
+
+    /**
+     * Constructor.
+     *
+     * @param KObjectConfig $config  An optional ObjectConfig object with configuration options
+     */
+    public function __construct(KObjectConfig $config)
+    {
+        parent::__construct($config);
+
+        //Set the command priority
+        $this->_priority = $config->priority;
+    }
+
+    /**
+     * Initializes the options for the object
+     *
+     * Called from {@link __construct()} as a first step of object instantiation.
+     *
+     * @param  KObjectConfig $config A ObjectConfig object with configuration options
+     * @return void
+     */
+    protected function _initialize(KObjectConfig $config)
+    {
+        $config->append(array(
+            'priority'   => self::PRIORITY_NORMAL,
+        ));
+
+        parent::_initialize($config);
+    }
+
+    /**
      * Connect the plugin to the dispatcher
      *
      * @param $dispatcher
@@ -39,11 +76,9 @@ abstract class PlgKoowaSubscriber extends PlgKoowaAbstract implements KEventSubs
      * Event listeners always start with 'on' and need to be public methods.
      *
      * @param KEventPublisherInterface $publisher
-     * @param  integer                 $priority   The event priority, usually between 1 (high priority) and 5 (lowest),
-     *                                 default is 3 (normal)
      * @return array An array of public methods that have been attached
      */
-    public function subscribe(KEventPublisherInterface $publisher, $priority = KEvent::PRIORITY_NORMAL)
+    public function subscribe(KEventPublisherInterface $publisher)
     {
         $handle = $publisher->getHandle();
 
@@ -53,7 +88,7 @@ abstract class PlgKoowaSubscriber extends PlgKoowaAbstract implements KEventSubs
 
             foreach ($listeners as $listener)
             {
-                $publisher->addListener($listener, array($this, $listener), $priority);
+                $publisher->addListener($listener, array($this, $listener), $this->getPriority());
                 $this->__publishers[$handle][] = $listener;
             }
         }
@@ -111,5 +146,15 @@ abstract class PlgKoowaSubscriber extends PlgKoowaAbstract implements KEventSubs
         }
 
         return $listeners;
+    }
+
+    /**
+     * Get the priority of a subscriber
+     *
+     * @return  integer The subscriber priority
+     */
+    public function getPriority()
+    {
+        return $this->_priority;
     }
 }

--- a/code/libraries/joomlatools/plugin/koowa/subscriber.php
+++ b/code/libraries/joomlatools/plugin/koowa/subscriber.php
@@ -23,26 +23,6 @@ abstract class PlgKoowaSubscriber extends PlgKoowaAbstract implements KEventSubs
     private $__publishers;
 
     /**
-     * The subscriber priority
-     *
-     * @var integer
-     */
-    protected $_priority;
-
-    /**
-     * Constructor.
-     *
-     * @param KObjectConfig $config  An optional ObjectConfig object with configuration options
-     */
-    public function __construct(KObjectConfig $config)
-    {
-        parent::__construct($config);
-
-        //Set the command priority
-        $this->_priority = $config->priority;
-    }
-
-    /**
      * Initializes the options for the object
      *
      * Called from {@link __construct()} as a first step of object instantiation.
@@ -155,6 +135,6 @@ abstract class PlgKoowaSubscriber extends PlgKoowaAbstract implements KEventSubs
      */
     public function getPriority()
     {
-        return $this->_priority;
+        return $this->getConfig()->priority;
     }
 }

--- a/code/plugins/system/joomlatools/joomlatools.php
+++ b/code/plugins/system/joomlatools/joomlatools.php
@@ -197,7 +197,6 @@ class PlgSystemJoomlatools extends JPlugin
     public function onException(KEventException $event)
     {
         KObjectManager::getInstance()->getObject('com:koowa.dispatcher.http')->fail($event);
-        return true;
     }
 
     /**


### PR DESCRIPTION
This PR allows an event subscriber to define the priority for each of the event handlers. This API was missing, while it was used here:  [code/libraries/joomlatools/component/koowa/event/subscriber/unauthorized.php#L21]( https://github.com/joomlatools/joomlatools-framework/blob/master/code/libraries/joomlatools/component/koowa/event/subscriber/unauthorized.php#L21)