### PR TITLE
#328 - Add support for Update_time to database table schema

### DIFF
--- a/code/libraries/joomlatools/library/database/adapter/mysqli.php
+++ b/code/libraries/joomlatools/library/database/adapter/mysqli.php
@@ -512,6 +512,7 @@ class KDatabaseAdapterMysqli extends KDatabaseAdapterAbstract
         $table->collation   = $info->Collation;
         $table->behaviors   = array();
         $table->description = $info->Comment != 'VIEW' ? $info->Comment : '';
+        $table->modified    = $info->Update_time;
 
         return $table;
     }

--- a/code/libraries/joomlatools/library/database/schema/table.php
+++ b/code/libraries/joomlatools/library/database/schema/table.php
@@ -65,6 +65,13 @@ class KDatabaseSchemaTable
     public $description;
 
     /**
+     * When the table was last updated
+     *
+     * @var timestamp
+     */
+    public $modified;
+
+    /**
      * List of columns
      *
      * Associative array of columns, where key holds the columns name and the value is an KDatabaseSchemaColumn


### PR DESCRIPTION
This PR add support for and translates MySQL `Update_time` table info property to `modified`. 