### PR TITLE
Metadata handling can lead to duplicates 

### DIFF
--- a/code/libraries/joomlatools/component/koowa/template/filter/meta.php
+++ b/code/libraries/joomlatools/component/koowa/template/filter/meta.php
@@ -44,8 +44,17 @@ class ComKoowaTemplateFilterMeta extends KTemplateFilterMeta
     {
         if($this->getTemplate()->decorator() == 'joomla')
         {
-            $meta = parent::_renderTag($attribs, $content);
-            JFactory::getDocument()->addCustomTag($meta);
+            if(isset($attribs['name'])) {
+                JFactory::getDocument()->setMetaData($attribs['name'], $attribs['content'], 'name');
+            }
+            elseif(isset($attribs['property'])) {
+                JFactory::getDocument()->setMetaData($attribs['property'], $attribs['content'], 'property');
+            }
+            else
+            {
+                $meta = parent::_renderTag($attribs, $content);
+                JFactory::getDocument()->addCustomTag($meta);
+            }
         }
         else return parent::_renderTag($attribs, $content);
     }


### PR DESCRIPTION
This PR tries to use the JFactory::setMetadata() api is possible. This API allows to override existing properties and therefor prevents duplicates. If  JFactory::setMetadata() cannot be used we revert to  JFactory::addCustomTag() as before.