### PR TITLE
Module filter params are not working

### DIFF
--- a/code/libraries/joomlatools/component/koowa/template/filter/module.php
+++ b/code/libraries/joomlatools/component/koowa/template/filter/module.php
@@ -289,7 +289,7 @@ class ComKoowaTemplateFilterModule extends KTemplateFilterAbstract
         $module->content   = $content;
         $module->id        = uniqid();
         $module->position  = $attributes['position'];
-        $module->params    = $attributes['params'];
+        $module->params    = htmlspecialchars_decode($attributes['params']);
         $module->showtitle = !empty($attributes['title']);
         $module->title     = $attributes['title'];
         $module->attribs   = $attributes;

--- a/code/libraries/joomlatools/component/koowa/template/filter/module.php
+++ b/code/libraries/joomlatools/component/koowa/template/filter/module.php
@@ -32,6 +32,11 @@ jimport('joomla.application.module.helper');
  * Example <khtml:modules position="sidebar" condition="sidebar >= 2"> In this case the sidebar will be rendered only
  * if at least two modules have been injected.
  *
+ * Params can be passed along when creating a module and should be encoded as a json string and especaded for xml
+ * compliance.
+ *
+ * Example <ktml:module position="sidebar" name="menu" params="<?= json(['menutype' => 'mainmenu'], true); ?>">
+ *
  * @author  Johan Janssens <https://github.com/johanjanssens>
  * @package Koowa\Component\Koowa\Template\Filter
  */

--- a/code/libraries/joomlatools/library/template/engine/abstract.php
+++ b/code/libraries/joomlatools/library/template/engine/abstract.php
@@ -91,7 +91,7 @@ abstract class KTemplateEngineAbstract extends KTemplateAbstract implements KTem
             'functions'    => array(
                 'object'    => array($this, 'getObject'),
                 'translate' => array($this->getObject('translator'), 'translate'),
-                'json'      => 'json_encode',
+                'json'      => array($this, 'jsonEncode'),
                 'format'    => 'sprintf',
                 'replace'   => 'strtr',
                 'debug'     => array($this, 'isDebug'),
@@ -99,6 +99,23 @@ abstract class KTemplateEngineAbstract extends KTemplateAbstract implements KTem
         ));
 
         parent::_initialize($config);
+    }
+
+    /**
+     *  Returns the JSON representation of a value
+     *
+     * @param $value mixed The value being encoded. Can be any type except a resource.
+     * @param $escape bool  If TRUE escapes the result for xml compliance. Default FALSE
+     */
+    public function jsonEncode($value, $escape = false)
+    {
+        $result = json_encode($value, JSON_HEX_QUOT);
+
+        if($escape) {
+            $result = htmlspecialchars($result);
+        }
+
+        return $result;
     }
 
     /**


### PR DESCRIPTION
Module params in Joomla are now json strings. To pass them as part of a module tag they need to be encoded to json and escaped for html compliance. 

This PR improve the json() template method to allow defining if the output should be escaped or not. Default the result is not escaped and it html decoded the params before passing them on to Joomla. 

The syntax to provide params when instantiation a module using is now:

````
<ktml:module position="sidebar" name="menu" params="<?= json(['menutype' => 'mainmenu'], true); ?>">
````