### PR TITLE
Disable Content-Length for non-downloadable requests

### DIFF
--- a/code/libraries/joomlatools/component/koowa/dispatcher/behavior/decoratable.php
+++ b/code/libraries/joomlatools/component/koowa/dispatcher/behavior/decoratable.php
@@ -95,10 +95,6 @@ class ComKoowaDispatcherBehaviorDecoratable extends KControllerBehaviorAbstract
         //Pass back to Joomla
         if(!$response->isRedirect() && !$response->isDownloadable() && $this->getDecorator() == 'joomla')
         {
-            // #237 - Since Joomla will wrap the page we do not know the actual content-length and should not send it
-            $response->getHeaders()->remove('Content-length');
-            header_remove('Content-Length');
-
             //Contenttype
             JFactory::getDocument()->setMimeEncoding($response->getContentType());
 


### PR DESCRIPTION
This PR removes unneeded code. The Content-Length is no longer being passed by default be the http transport for none downloadable requests. See: https://github.com/joomlatools/joomlatools-framework/issues/366