### PR TITLE
Improve user object group and role handling

### DIFF
--- a/code/libraries/joomlatools/component/koowa/database/table/groups.php
+++ b/code/libraries/joomlatools/component/koowa/database/table/groups.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Joomlatools Framework - https://www.joomlatools.com/developer/framework/
+ *
+ * @copyright   Copyright (C) 2007 Johan Janssens and Timble CVBA. (http://www.timble.net)
+ * @license     GNU GPLv3 <http://www.gnu.org/licenses/gpl.html>
+ * @link        https://github.com/joomlatools/joomlatools-framework for the canonical source repository
+ */
+
+/**
+ * Database table for Joomla groups
+ *
+ * @author  Johan Janssens <https://github.com/johanjanssens>
+ * @package Koowa\Component\Koowa\Database\Table
+ */
+class ComKoowaDatabaseTableGroups extends KDatabaseTableAbstract
+{
+    protected function _initialize(KObjectConfig $config)
+    {
+        $config->append([
+            'name' => defined('JOOMLATOOLS_PLATFORM') ? 'users_groups' : 'usergroups'
+        ]);
+
+        parent::_initialize($config);
+    }
+}

--- a/code/libraries/joomlatools/component/koowa/database/table/roles.php
+++ b/code/libraries/joomlatools/component/koowa/database/table/roles.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Joomlatools Framework - https://www.joomlatools.com/developer/framework/
+ *
+ * @copyright   Copyright (C) 2007 Johan Janssens and Timble CVBA. (http://www.timble.net)
+ * @license     GNU GPLv3 <http://www.gnu.org/licenses/gpl.html>
+ * @link        https://github.com/joomlatools/joomlatools-framework for the canonical source repository
+ */
+
+/**
+ * Database table for Joomla roles
+ *
+ * @author  Johan Janssens <https://github.com/johanjanssens>
+ * @package Koowa\Component\Koowa\Database\Table
+ */
+class ComKoowaDatabaseTableRoles extends KDatabaseTableAbstract
+{
+    protected function _initialize(KObjectConfig $config)
+    {
+        $config->append([
+            'name' => defined('JOOMLATOOLS_PLATFORM') ? 'users_roles' : 'viewlevels'
+        ]);
+
+        parent::_initialize($config);
+    }
+}

--- a/code/libraries/joomlatools/component/koowa/event/subscriber/user.php
+++ b/code/libraries/joomlatools/component/koowa/event/subscriber/user.php
@@ -23,7 +23,7 @@ class ComKoowaEventSubscriberUser extends KEventSubscriberAbstract
         $user = $this->getObject('user');
 
         if (!$user->isAuthentic()) {
-            $user->setUser($event->user);
+            $user->setData($event->user);
         }
 
         $menu = JFactory::getApplication()->getMenu();

--- a/code/libraries/joomlatools/component/koowa/user/default.php
+++ b/code/libraries/joomlatools/component/koowa/user/default.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Joomlatools Framework - https://www.joomlatools.com/developer/framework/
+ *
+ * @copyright   Copyright (C) 2007 Johan Janssens and Timble CVBA. (http://www.timble.net)
+ * @license     GNU GPLv3 <http://www.gnu.org/licenses/gpl.html>
+ * @link        https://github.com/joomlatools/joomlatools-framework for the canonical source repository
+ */
+
+/**
+ * Default User
+ *
+ * @author  Johan Janssens <https://github.com/johanjanssens>
+ * @package Koowa\Component\Koowa\User
+ */
+final class ComKoowaUserDefault extends KUserAbstract implements ComKoowaUserInterface
+{
+    use ComKoowaUserTrait;
+}

--- a/code/libraries/joomlatools/component/koowa/user/provider.php
+++ b/code/libraries/joomlatools/component/koowa/user/provider.php
@@ -20,7 +20,7 @@ final class ComKoowaUserProvider extends KUserProvider
      *
      * @param string $identifier A unique user identifier, (i.e a username or user id)
      * @param bool  $refresh     If TRUE and the user has already been loaded it will be re-loaded.
-     * @return KUserInterface Returns a UserInterface object.
+     * @return ComKoowaUserInterface Returns a UserInterface object.
      */
     public function load($identifier, $refresh = false)
     {
@@ -39,7 +39,7 @@ final class ComKoowaUserProvider extends KUserProvider
         {
             $user = parent::load($identifier, $refresh);
 
-            if (!$user instanceof KUserInterface)
+            if (!$user instanceof ComKoowaUserInterface)
             {
                 $user = $this->create(array(
                     'id'   => $identifier,
@@ -55,7 +55,7 @@ final class ComKoowaUserProvider extends KUserProvider
      * Fetch the user for the given user identifier from the backend
      *
      * @param string $identifier A unique user identifier, (i.e a username or email address)
-     * @return KUserInterface|null Returns a UserInterface object or NULL if the user could not be found.
+     * @return ComKoowaUserInterface|null Returns a UserInterface object or NULL if the user could not be found.
      */
     public function fetch($identifier)
     {
@@ -94,11 +94,23 @@ final class ComKoowaUserProvider extends KUserProvider
     }
 
     /**
+     * Create a user object
+     *
+     * @param array $data An associative array of user data
+     * @return ComKoowaUserInterface     Returns a UserInterface object
+     */
+    public function create($data)
+    {
+        $user = $this->getObject('com:koowa.user.default', array('data' => $data));
+        return $user;
+    }
+
+    /**
      * Store a user object in the provider
      *
      * @param string $identifier A unique user identifier, (i.e a username or email address)
      * @param array $data An associative array of user data
-     * @return KUserInterface     Returns a UserInterface object
+     * @return ComKoowaUserInterface     Returns a UserInterface object
      */
     public function store($identifier, $data)
     {

--- a/code/libraries/joomlatools/component/koowa/user/trait.php
+++ b/code/libraries/joomlatools/component/koowa/user/trait.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Joomlatools Framework - https://www.joomlatools.com/developer/framework/
+ *
+ * @copyright   Copyright (C) 2007 Johan Janssens and Timble CVBA. (http://www.timble.net)
+ * @license     GNU GPLv3 <http://www.gnu.org/licenses/gpl.html>
+ * @link        https://github.com/joomlatools/joomlatools-framework for the canonical source repository
+ */
+
+/**
+ * User Trait
+ *
+ * This trait implements specific Joomla user functionality
+ *
+ * @author  Johan Janssens <https://github.com/johanjanssens>
+ * @package Koowa\Component\Koowa\User
+ */
+trait ComKoowaUserTrait
+{
+    private $__groups  = null;
+    private $__roles   = null;
+
+    /**
+     * Returns the username of the user
+     *
+     * @return string The name
+     */
+    public function getUsername()
+    {
+        return $this->getData()->username;
+    }
+
+    /**
+     * Method to get a parameter value
+     *
+     * @param   string  $key      Parameter key
+     * @param   mixed   $default  Parameter default value
+     * @return  mixed  The value or the default if it did not exist
+     */
+    public function getParameter($key, $default = null)
+    {
+        return JFactory::getUser()->getParam($key, $default);
+    }
+
+    /**
+     * Returns the roles of the user
+     *
+     * @param  bool  $by_name Return the roles by name instead of by id
+     * @return array The role id's or names
+     */
+    public function getRoles($by_name = false)
+    {
+        $roles = parent::getRoles();
+
+        //Convert to names
+        if($by_name)
+        {
+            if(!isset($this->__roles))
+            {
+                //Get the user roles
+                $roles = $this->getObject('com:koowa.database.table.roles')
+                    ->select($roles, KDatabase::FETCH_ARRAY_LIST);
+
+                $this->__roles = array_map('strtolower', array_column($roles, 'title'));
+            }
+
+            $roles = $this->__roles;
+        }
+
+        return $roles;
+    }
+
+    /**
+     * Checks if the user has a role.
+     *
+     * @param  mixed|array $roles A role name or id or an array containing role names id's.
+     * @return bool True if the user has at least one of the provided roles, false otherwise.
+     */
+    public function hasRole($roles)
+    {
+        $result = false;
+
+        foreach((array)$roles as $role)
+        {
+            if(is_numeric($role)) {
+                $result = in_array($role, $this->getRoles());
+            } else {
+                $result = in_array($role, $this->getRoles(true));
+            }
+
+            if($result == true) {
+                break;
+            }
+        }
+
+        return (bool) $result;
+    }
+
+    /**
+     * Returns the groups the user is part of
+     *
+     * @param  bool  $by_name Return the groups by name instead of by id
+     * @return array An array of group id's or names
+     */
+    public function getGroups($by_name = false)
+    {
+        $groups = parent::getGroups();
+
+        //Convert to names
+        if($by_name)
+        {
+            if(!isset($this->__groups))
+            {
+                //Get the user groups
+                $groups = $this->getObject('com:koowa.database.table.groups')
+                    ->select($groups, KDatabase::FETCH_ARRAY_LIST);
+
+                $this->__groups = array_map('strtolower', array_column($groups, 'title'));
+            }
+
+            $groups = $this->__groups;
+        }
+
+        return $groups;
+    }
+
+    /**
+     * Checks if the user is part of a group.
+     *
+     * @param  mixed|array $groups A group name or id or an array containing group names or id's.
+     * @return bool True if the user has at least one of the provided groups, false otherwise.
+     */
+    public function hasGroup($groups)
+    {
+        $result = false;
+
+        foreach((array) $groups as $group)
+        {
+            if(is_numeric($group)) {
+                $result = in_array($group, $this->getGroups());
+            } else {
+                $result = in_array($group, $this->getGroups(true));
+            }
+
+            if($result == true) {
+                break;
+            }
+        }
+
+        return (bool) $result;
+    }
+
+    /**
+     * Method to check object authorisation against an access control object and optionally an access extension object
+     *
+     * @param   string  $action     The name of the action to check for permission.
+     * @param   string  $assetname  The name of the asset on which to perform the action.
+     * @return  boolean  True if authorised
+     */
+    public function authorise($action, $assetname = null)
+    {
+        return JFactory::getUser()->authorise($action, $assetname);
+    }
+}

--- a/code/libraries/joomlatools/component/koowa/user/trait.php
+++ b/code/libraries/joomlatools/component/koowa/user/trait.php
@@ -73,10 +73,11 @@ trait ComKoowaUserTrait
     /**
      * Checks if the user has a role.
      *
-     * @param  mixed|array $roles A role name or id or an array containing role names id's.
-     * @return bool True if the user has at least one of the provided roles, false otherwise.
+     * @param  mixed|array $role A role name or an array containing role names.
+     * @param  bool        $strict If true, the user has to have all the provided roles, not just one
+     * @return bool
      */
-    public function hasRole($roles)
+    public function hasRole($roles, $strict = false)
     {
         $result = false;
 
@@ -88,8 +89,10 @@ trait ComKoowaUserTrait
                 $result = in_array($role, $this->getRoles(true));
             }
 
-            if($result == true) {
-                break;
+            if(!$strict) {
+                if($result == true) break;
+            } else {
+                if($result == false) break;
             }
         }
 
@@ -125,12 +128,13 @@ trait ComKoowaUserTrait
     }
 
     /**
-     * Checks if the user is part of a group.
+     * Checks if the user is part of a group
      *
-     * @param  mixed|array $groups A group name or id or an array containing group names or id's.
-     * @return bool True if the user has at least one of the provided groups, false otherwise.
+     * @param  mixed|array $group A role name or an array containing group names.
+     * @param  bool        $strict If true, the user needs to be part of all provided group(s), not just one.
+     * @return bool
      */
-    public function hasGroup($groups)
+    public function hasGroup($groups, $strict = false)
     {
         $result = false;
 
@@ -142,8 +146,10 @@ trait ComKoowaUserTrait
                 $result = in_array($group, $this->getGroups(true));
             }
 
-            if($result == true) {
-                break;
+            if(!$strict) {
+                if($result == true) break;
+            } else {
+                if($result == false) break;
             }
         }
 

--- a/code/libraries/joomlatools/component/koowa/user/user.php
+++ b/code/libraries/joomlatools/component/koowa/user/user.php
@@ -33,12 +33,12 @@ final class ComKoowaUser extends KUser implements ComKoowaUserInterface
     /**
      * Set the user data
      *
-     * @param  array|JUser $user An associative array of data or a JUser object
+     * @param  array|JUser|Joomla\CMS\User\User $user An associative array of data or a JUser object
      * @return $this
      */
     public function setData($user)
     {
-        if($user instanceof JUser)
+        if($user instanceof JUser || $user instanceof \Joomla\CMS\User\User)
         {
             $data = array(
                 'id'         => $user->id,

--- a/code/libraries/joomlatools/component/koowa/user/user.php
+++ b/code/libraries/joomlatools/component/koowa/user/user.php
@@ -15,55 +15,49 @@
  */
 final class ComKoowaUser extends KUser implements ComKoowaUserInterface
 {
-    private $__groups  = null;
-    private $__roles   = null;
+    use ComKoowaUserTrait;
 
-    protected function _initialize(KObjectConfig $config)
+    /**
+     * Constructor
+     *
+     * @param KObjectConfig $config An optional KObjectConfig object with configuration options.
+     */
+    public function __construct(KObjectConfig $config)
     {
-        $user = JFactory::getUser();
+        KObject::__construct($config);
 
-        $config->append(array(
-            'data' => $this->_mapData($user)
-        ));
-
-        parent::_initialize($config);
+        //Set the user properties and attributes
+        $this->setData(JFactory::getUser());
     }
 
     /**
-     * User setter
+     * Set the user data
      *
-     * @param JUser $user A joomla user object
-     *
+     * @param  array|JUser $user An associative array of data or a JUser object
      * @return $this
      */
-    public function setUser(JUser $user)
+    public function setData($user)
     {
-        $this->setData($this->_mapData($user));
+        if($user instanceof JUser)
+        {
+            $data = array(
+                'id'         => $user->id,
+                'email'      => $user->email,
+                'name'       => $user->name,
+                'username'   => $user->username,
+                'password'   => $user->password,
+                'salt'       => '',
+                'groups'     => JAccess::getGroupsByUser($user->id),
+                'roles'      => JAccess::getAuthorisedViewLevels($user->id),
+                'authentic'  => !$user->guest,
+                'enabled'    => !$user->block,
+                'expired'    => !$user->activation,
+                'attributes' => $user->getParameters()->toArray()
+            );
+        }
+        else $data = $user;
 
-        return $this;
-    }
-
-    /**
-     * Joomla user to Koowa user data mapper
-     *
-     * @param JUser $user
-     *
-     * @return array Koowa user data
-     */
-    protected function _mapData(JUser $user)
-    {
-        return array(
-            'id'         => $user->id,
-            'email'      => $user->email,
-            'name'       => $user->name,
-            'username'   => $user->username,
-            'password'   => $user->password,
-            'salt'       => '',
-            'authentic'  => !$user->guest,
-            'enabled'    => !$user->block,
-            'expired'    => !$user->activation,
-            'attributes' => $user->getParameters()->toArray()
-        );
+        return parent::setData($data);
     }
 
     /**
@@ -74,149 +68,5 @@ final class ComKoowaUser extends KUser implements ComKoowaUserInterface
     public function getUsername()
     {
         return $this->getSession()->get('user.username');
-    }
-
-    /**
-     * Method to get a parameter value
-     *
-     * @param   string  $key      Parameter key
-     * @param   mixed   $default  Parameter default value
-     * @return  mixed  The value or the default if it did not exist
-     */
-    public function getParameter($key, $default = null)
-    {
-        return JFactory::getUser()->getParam($key, $default);
-    }
-
-    /**
-     * Returns the roles of the user
-     *
-     * @param  bool  $by_name Return the roles by name instead of by id
-     * @return array The role id's or names
-     */
-    public function getRoles($by_name = false)
-    {
-        $data  = $this->getData();
-        $roles = KObjectConfig::unbox($data->roles);
-
-        if(empty($roles)) {
-            $this->getSession()->set('user.roles', JAccess::getAuthorisedViewLevels($this->getId()));
-        }
-
-        //Convert to names
-        if($by_name)
-        {
-            if(!isset($this->__roles))
-            {
-                //Get the user roles
-                $roles = $this->getObject('com:koowa.database.table.roles')
-                    ->select(parent::getRoles(), KDatabase::FETCH_ARRAY_LIST);
-
-                $this->__roles = array_map('strtolower', array_column($roles, 'title'));
-            }
-
-            $result = $this->__roles;
-        }
-        else $result = parent::getRoles();
-
-        return $result;
-    }
-
-    /**
-     * Checks if the user has a role.
-     *
-     * @param  mixed|array $roles A role name or id or an array containing role names id's.
-     * @return bool True if the user has at least one of the provided roles, false otherwise.
-     */
-    public function hasRole($roles)
-    {
-        $result = false;
-
-        foreach((array)$roles as $role)
-        {
-            if(is_numeric($role)) {
-                $result = in_array($role, $this->getRoles());
-            } else {
-                $result = in_array($role, $this->getRoles(true));
-            }
-
-            if($result == true) {
-                break;
-            }
-        }
-
-        return (bool) $result;
-    }
-
-    /**
-     * Returns the groups the user is part of
-     *
-     * @param  bool  $by_name Return the groups by name instead of by id
-     * @return array An array of group id's or names
-     */
-    public function getGroups($by_name = false)
-    {
-        $data  = $this->getData();
-        $groups = KObjectConfig::unbox($data->groups);
-
-        if(empty($groups)) {
-            $this->getSession()->set('user.groups', JAccess::getGroupsByUser($this->getId()));
-        }
-
-        //Convert to names
-        if($by_name)
-        {
-            if(!isset($this->__groups))
-            {
-                //Get the user groups
-                $groups = $this->getObject('com:koowa.database.table.groups')
-                    ->select(parent::getGroups(), KDatabase::FETCH_ARRAY_LIST);
-
-                $this->__groups = array_map('strtolower', array_column($groups, 'title'));
-            }
-
-            $result = $this->__groups;
-        }
-        else $result =  parent::getGroups();
-
-        return $result;
-    }
-
-    /**
-     * Checks if the user is part of a group.
-     *
-     * @param  mixed|array $groups A group name or id or an array containing group names or id's.
-     * @return bool True if the user has at least one of the provided groups, false otherwise.
-     */
-    public function hasGroup($groups)
-    {
-        $result = false;
-
-        foreach((array) $groups as $group)
-        {
-            if(is_numeric($group)) {
-                $result = in_array($group, $this->getGroups());
-            } else {
-                $result = in_array($group, $this->getGroups(true));
-            }
-
-            if($result == true) {
-                break;
-            }
-        }
-
-        return (bool) $result;
-    }
-
-    /**
-     * Method to check object authorisation against an access control object and optionally an access extension object
-     *
-     * @param   string  $action     The name of the action to check for permission.
-     * @param   string  $assetname  The name of the asset on which to perform the action.
-     * @return  boolean  True if authorised
-     */
-    public function authorise($action, $assetname = null)
-    {
-        return JFactory::getUser()->authorise($action, $assetname);
     }
 }

--- a/code/libraries/joomlatools/library/user/abstract.php
+++ b/code/libraries/joomlatools/library/user/abstract.php
@@ -149,6 +149,18 @@ abstract class KUserAbstract extends KObject implements KUserInterface
     }
 
     /**
+     * Checks if the user is part of of a group
+     *
+     * @param  mixed|array $group A role name or an array containing group names.
+     * @return bool True if the user is at least part of one of the provided group(s), false otherwise.
+     */
+    public function hasGroup($group)
+    {
+        $groups = (array) $group;
+        return (bool) array_intersect($this->getGroups(), $groups);
+    }
+
+    /**
      * Returns the password used to authenticate the user.
      *
      * This should be the encoded password. On authentication, a plain-text password will be salted, encoded, and

--- a/code/libraries/joomlatools/library/user/abstract.php
+++ b/code/libraries/joomlatools/library/user/abstract.php
@@ -323,4 +323,14 @@ abstract class KUserAbstract extends KObject implements KUserInterface
     {
         return KObjectConfig::unbox($this->getData());
     }
+
+    /**
+     * Dumping user object
+     *
+     * @return mixed
+     */
+    public function __debugInfo()
+    {
+        return $this->toArray();
+    }
 }

--- a/code/libraries/joomlatools/library/user/abstract.php
+++ b/code/libraries/joomlatools/library/user/abstract.php
@@ -130,12 +130,20 @@ abstract class KUserAbstract extends KObject implements KUserInterface
      * Checks if the user has a role.
      *
      * @param  mixed|array $role A role name or an array containing role names.
-     * @return bool True if the user has at least one of the provided roles, false otherwise.
+     * @param  bool        $strict If true, the user has to have all the provided roles, not just one
+     * @return bool
      */
-    public function hasRole($role)
+    public function hasRole($role, $strict = false)
     {
         $roles = (array) $role;
-        return (bool) array_intersect($this->getRoles(), $roles);
+
+        if($strict) {
+            $result = !array_diff($roles, $this->getRoles());
+        } else {
+            $result =  (bool) array_intersect($this->getRoles(), $roles);
+        }
+
+        return $result;
     }
 
     /**
@@ -149,15 +157,23 @@ abstract class KUserAbstract extends KObject implements KUserInterface
     }
 
     /**
-     * Checks if the user is part of of a group
+     * Checks if the user is part of a group
      *
      * @param  mixed|array $group A role name or an array containing group names.
-     * @return bool True if the user is at least part of one of the provided group(s), false otherwise.
+     * @param  bool        $strict If true, the user needs to be part of all provided group(s), not just one.
+     * @return bool
      */
-    public function hasGroup($group)
+    public function hasGroup($group, $strict = false)
     {
         $groups = (array) $group;
-        return (bool) array_intersect($this->getGroups(), $groups);
+
+        if($strict) {
+            $result = !array_diff($groups, $this->getGroups());
+        } else {
+            $result = (bool) array_intersect($this->getGroups(), $groups);
+        }
+
+        return $result;
     }
 
     /**

--- a/code/libraries/joomlatools/library/user/interface.php
+++ b/code/libraries/joomlatools/library/user/interface.php
@@ -59,6 +59,14 @@ interface KUserInterface extends KObjectEquatable
     public function getGroups();
 
     /**
+     * Checks if the user is part of a group
+     *
+     * @param  mixed|array $group A role name or an array containing group names.
+     * @return bool True if the user is at least part of one of the provided group(s), false otherwise.
+     */
+    public function hasGroup($group);
+
+    /**
      * Returns the password used to authenticate the user.
      *
      * This should be the encoded password. On authentication, a plain-text password will be salted, encoded, and

--- a/code/libraries/joomlatools/library/user/interface.php
+++ b/code/libraries/joomlatools/library/user/interface.php
@@ -47,9 +47,10 @@ interface KUserInterface extends KObjectEquatable
      * Checks if the user has a role.
      *
      * @param  mixed|array $role A role name or an array containing role names.
+     * @param  bool        $strict If true, the user has to have all the provided roles, not just one
      * @return bool True if the user has at least one of the provided roles, false otherwise.
      */
-    public function hasRole($role);
+    public function hasRole($role, $strict = false);
 
     /**
      * Returns the groups the user is part of
@@ -61,10 +62,11 @@ interface KUserInterface extends KObjectEquatable
     /**
      * Checks if the user is part of a group
      *
-     * @param  mixed|array $group A role name or an array containing group names.
-     * @return bool True if the user is at least part of one of the provided group(s), false otherwise.
+     * @param  mixed|array $group A role name or an array containing group names.©≈©
+     * @param  bool        $strict If true, the user needs to be part of all provided group(s), not just one.
+     * @return bool
      */
-    public function hasGroup($group);
+    public function hasGroup($group, $strict = false);
 
     /**
      * Returns the password used to authenticate the user.


### PR DESCRIPTION
This PR closes #383 and implements following changes:

- Allow to get groups by name or id (default)
- Allow to get roles by name or id (default)
- Allow to check if a user has a role by name
- Allow to check if a user is part of a group by name

Both the `KUser::getGroups()`and `KUser::getRoles()` methods have an additional `$by_name`parameter (default is false) which will return the groups or roles by name instead of id.

Both the `KUser:hasGroup()`and `KUser::hasRole()` methods accept group or role names for lookups. If an array is passed it's possible to use both id's or names interchangeably. The code can handle this.

A second `strict`parameter has also been added to both, if true the user needs to be part of all the groups or has all the roles provided. If not the methods will return false.

### Notes: 

- The changes cleanup the work done in https://github.com/joomlatools/joomlatools-framework/pull/276. The `setUser()`method has been removed and the re-implemented as part of the `setData()`method. This gives a cleaner API. 


