### PR TITLE
Encode space as %20 instead of + in path

### DIFF
--- a/code/libraries/joomlatools/library/http/url/url.php
+++ b/code/libraries/joomlatools/library/http/url/url.php
@@ -163,7 +163,7 @@ class KHttpUrl extends KObject implements KHttpUrlInterface
      * @var array
      */
     protected $_encode_path = array(
-        ' ' => '+',
+        ' ' => '%20',
         '/' => '%2F',
         '?' => '%3F',
         '&' => '%26',


### PR DESCRIPTION
Rule: **You should have %20 before the ? and + after.**

Source: 

- https://stackoverflow.com/questions/1634271/url-encoding-the-space-character-or-20
- https://web.archive.org/web/20151218094722/http://blog.lunatech.com/2009/02/03/what-every-web-developer-must-know-about-url-encoding