### PR TITLE
Xdebug 2.9.2 support

### DIFF
--- a/code/libraries/joomlatools/component/koowa/exception/handler.php
+++ b/code/libraries/joomlatools/component/koowa/exception/handler.php
@@ -44,7 +44,7 @@ final class ComKoowaExceptionHandler extends KExceptionHandler
      */
     protected function _initialize(KObjectConfig $config)
     {
-        if(extension_loaded('xdebug'))
+        if(extension_loaded('xdebug') && xdebug_is_enabled() && getenv('JOOMLATOOLS_BOX'))
         {
             $level = self::ERROR_DEVELOPMENT;
             $type  = self::TYPE_ALL;


### PR DESCRIPTION
I am using Xdebug 2.9.2 (on Ubuntu 20.04 + PHP 7.4). 
PR https://github.com/joomlatools/joomlatools-framework/pull/448 seems to crash my environment with Xdebug 2.9.2 crash with a 500 error.

When I change the 
```if(extension_loaded('xdebug')```
back to 
```if(extension_loaded('xdebug') && xdebug_is_enabled() && getenv('JOOMLATOOLS_BOX'))```
it works ok again