### PR TITLE
Update abstract.php

### DIFF
--- a/code/libraries/joomlatools/library/dispatcher/request/abstract.php
+++ b/code/libraries/joomlatools/library/dispatcher/request/abstract.php
@@ -208,7 +208,7 @@ abstract class KDispatcherRequestAbstract extends KControllerRequest implements 
                     $data = json_decode($content, true);
                 }
 
-                $this->data->add($data);
+                $this->data->add($data ?? []);
             }
         }
 


### PR DESCRIPTION
When content-type is set to Application/json, joomlatools intercept the POST request. If the json is malformated a 500 error message comes out:  KHttpMessageParameters::add(): Argument #1 ($parameters) must be of type array, null given. This error doesn't allow you to debug your own app.