### PR TITLE
Fix #761: Replace deprecated get_class() call without arguments

### DIFF
--- a/code/libraries/joomlatools/library/command/mixin/mixin.php
+++ b/code/libraries/joomlatools/library/command/mixin/mixin.php
@@ -206,7 +206,7 @@ class KCommandMixin extends KCommandCallbackAbstract implements KCommandMixinInt
         if (is_string($method) && !method_exists($this->getMixer(), $method))
         {
             throw new InvalidArgumentException(
-                'Method does not exist '.get_class().'::'.$method
+                'Method does not exist '.self::class.'::'.$method
             );
         }
 


### PR DESCRIPTION
Closes #761.

PHP 8.3 deprecates calling `get_class()` without arguments. This replaces the no-arg call in `KCommandMixin::addCommandCallback()` with `self::class` (the exact equivalent — the defining class name).